### PR TITLE
changed the partner sign up page link to the Marketo powered form

### DIFF
--- a/docs/get-started.md
+++ b/docs/get-started.md
@@ -10,8 +10,8 @@ The following guide explains the process that you need to go through in order to
 
 ## 1. Sign up as a content development partner
 
-<a href="https://go.demisto.com/become-a-technology-partner" target="_blank">Submit your application now!</a> After your application is approved you’ll receive an email with resources to help you get started. Once you receive it, we recommend you review the resources including the docs here, our GitHub repository, and Support Portal to assist you in content development.
-<a class="button" href="https://go.demisto.com/become-a-technology-partner" target="_blank">Sign Up Now</a>
+<a href="https://start.paloaltonetworks.com/become-a-technology-partner" target="_blank">Submit your application now!</a> After your application is approved you’ll receive an email with resources to help you get started. Once you receive it, we recommend you review the resources including the docs here, our GitHub repository, and Support Portal to assist you in content development.
+<a class="button" href="https://start.paloaltonetworks.com/become-a-technology-partner" target="_blank">Sign Up Now</a>
 
 ## 2. Complete the technical partnership agreement
 

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -49,7 +49,7 @@ module.exports = {
           position: "left"
         },
         {
-          href: "https://go.demisto.com/become-a-technology-partner",
+          href: "https://start.paloaltonetworks.com/become-a-technology-partner",
           label: "Sign Up Now",
           position: "right"
         },

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -168,7 +168,7 @@ function Home() {
                     "button button--outline button--secondary button--lg",
                     styles.indexCtasGetStartedButton
                   )}
-                  href="https://go.demisto.com/become-a-technology-partner"
+                  href="https://start.paloaltonetworks.com/become-a-technology-partner"
                 >
                   Sign Up Now!
                 </Link>


### PR DESCRIPTION
Changed the partner signup link to the new form powered by Marketo: https://start.paloaltonetworks.com/become-a-technology-partner