### PR TITLE
Fixed the 'Get Started Now' link in the 'Why Demisto' page

### DIFF
--- a/docs/why-demisto.mdx
+++ b/docs/why-demisto.mdx
@@ -56,5 +56,5 @@ We will support you as you build. Here’s a few of the ways
 - Portal - You’ll be granted a portal account with full help documentation.  
 - Live resources - And of course we have live technical resources to step in when the above is exhausted.
 
-	<a href="/docs/en/get-started" class="button">Get Started Now</a>
+<a class="button button--outline button--primary button--lg" href="/docs/get-started">Get Started Now!</a>
 


### PR DESCRIPTION
Link was incorrectly visualized and was broken. Also changed it to a button