### PR TITLE
Change navbar search input and background color in dark mode

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -14,14 +14,13 @@
 /* You can override the default Infima variables here. */
 
 :root {
-  --ifm-color-primary: #98C23D;
-  --ifm-color-primary-dark: #A7CB5A;
-  --ifm-color-primary-darker: #B6D477;
-  --ifm-color-primary-dt: #C7DE95;
-  --ifm-color-primary-light: #D6E7B1;
-  --ifm-color-primary-lighter: #E5F0CE;
-  --ifm-color-primary-lightest: #F4F8EB;
-
+  --ifm-color-primary: #98c23d;
+  --ifm-color-primary-dark: #a7cb5a;
+  --ifm-color-primary-darker: #b6d477;
+  --ifm-color-primary-dt: #c7de95;
+  --ifm-color-primary-light: #d6e7b1;
+  --ifm-color-primary-lighter: #e5f0ce;
+  --ifm-color-primary-lightest: #f4f8eb;
 }
 
 /* Dark mode overrides */
@@ -48,13 +47,14 @@ html[data-theme="dark"] {
   /* Mardown color in dark mode */
   --ifm-color-gray-800: var(--ifm-color-gray-300);
 
-
+  /* Search input color in dark mode */
+  --ifm-navbar-search-input-color: var(--ifm-color-gray-900);
+  --ifm-navbar-search-input-background-color: #fff;
 }
 
 .footer.footer--dark {
   --ifm-footer-background-color: #333333;
 }
-
 
 /* Docs overrides */
 .markdown p {
@@ -123,7 +123,7 @@ blockquote {
 
 .customer {
   color: #fff;
-  background-color: #98C23D;
+  background-color: #98c23d;
   font-weight: bold;
   font-size: 35px;
   padding: 48px;


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Status
Ready for review

## Related Issues
fixes: Addresses issue mentioned in #34 

## Description
Added custom CSS to darken the search bar text color and lighten background in dark mode.

(Note that Prettier performed additional minor formatting changes to the CSS)

## Screenshots

![Screen Shot 2020-01-07 at 9 32 01 AM](https://user-images.githubusercontent.com/9343811/71906929-aaaee000-3130-11ea-9e11-c7883024a86e.png)

![Screen Shot 2020-01-07 at 9 31 56 AM](https://user-images.githubusercontent.com/9343811/71906934-ada9d080-3130-11ea-8815-596aef239f1d.png)
