### PR TITLE
Fixed broken link on code-conventions

### DIFF
--- a/docs/integrations/code-conventions.md
+++ b/docs/integrations/code-conventions.md
@@ -4,14 +4,14 @@ title: Code Conventions
 ---
 
 ## Python Code Conventions
-We use standardized code conventions to ensure uniformity across all Demisto Integrations. This section outlines our code conventions.\
+We use standardized code conventions to ensure uniformity across all Demisto Integrations. This section outlines our code conventions.
 
 New integrations and scripts should follow these conventions. When working on small fixes and modifications to existing code, follow the conventions used in the existing code.
 
 **Note:** Demisto supports also JavaScript integrations and scripts. Our preferred development language is Python, and all new integrations and scripts should be developed in Python, which also provides a wider set of capabilities compared to the available JavaScript support. Simple scripts may still be developed in JavaScript using the conventions provided by the default script template used in the Demisto IDE.
 
 ## Example Code and Templates
-For an example of a **Hello World** integration see [HelloWorld](https://github.com/demisto/content/tree/master/Integrations/HelloWorld).
+For an example of a **Hello World** integration see [HelloWorld](https://github.com/demisto/content/tree/master/Packs/HelloWorld/Integrations/HelloWorld).
 
 For quick starts templates see [Templates directory](https://github.com/demisto/content/tree/master/Templates).
 


### PR DESCRIPTION
Fixes: https://github.com/demisto/content-docs/issues/65

## Status
Ready

## Related Issues
fixes: https://github.com/demisto/content-docs/issues/65

## Description
Fixes link to Hello World in code conventions
Also fixes trailing backslash in first paragraph
