### PR TITLE
Update context outputs doc

### DIFF
--- a/docs/integrations/context-and-outputs.md
+++ b/docs/integrations/context-and-outputs.md
@@ -133,7 +133,11 @@ return_outputs(
 )
 ```
 
-**Note**: The code **must** match the context path in the yml
+**Notes**: 
+  - The code **must** match the context path in the yml.
+  - You can output the API response as is to the context as value, under the brand name key.
+    That is, no need to modify the API response and map it to human readable keys.
+    You might see old integrations in which this map exist, but this is no longer required. 
 
 ### DT (Demisto Transform Language)
 In the above example, we observe the entry context using ```(val.ReportID == obj.ReportID)```. This works to *tie together* related entry context objects. In this instance, we are using the value of the ReportID key as the unique identifier to search through the existing context and link related objects. This prevents data from being overwritten as well as further enriches an existing entry with more information. Learn more about linking context [here](dt).


### PR DESCRIPTION
## Status
Ready

## Description
Updated the context outputs doc, according to our latest decision, to pass the API response as is to the context without modifying it.
