### PR TITLE
optimize build so on pr we build a preview of reference docs

### DIFF
--- a/content-repo/create-docs.sh
+++ b/content-repo/create-docs.sh
@@ -87,10 +87,22 @@ else
         exit 2
     fi
     echo "Couldn't find $CONTENT_BRANCH using master to generate build"
+    CONTENT_BRANCH=master
     git checkout master
 fi
 
 cd ${SCRIPT_DIR}
+
+if [[ "$PULL_REQUEST" == "true" && "$CONTENT_BRANCH" == "master" ]]; then
+    echo "Checking if only doc files where modified and we can do a limited preview build..."
+    DIFF_FILES=$(git diff --name-only  origin/master...HEAD)  # so we fail on errors if there is a problem
+    echo -e "Modified files:\n$DIFF_FILES\n-----------"    
+    echo "$DIFF_FILES" | grep -v -E '^docs/' || MAX_FILES=20    
+    if [ -n "$MAX_FILES" ]; then
+        echo "MAX_FILES set to: $MAX_FILES"
+        export MAX_FILES
+    fi
+fi
 
 TARGET_DIR=${SCRIPT_DIR}/../docs/reference
 echo "Deleting and creating dir: ${TARGET_DIR}"

--- a/content-repo/create-docs.sh
+++ b/content-repo/create-docs.sh
@@ -94,10 +94,11 @@ fi
 cd ${SCRIPT_DIR}
 
 if [[ "$PULL_REQUEST" == "true" && "$CONTENT_BRANCH" == "master" ]]; then
-    echo "Checking if only doc files where modified and we can do a limited preview build..."
-    git remote -v
+    echo "Checking if only doc files where modified and we can do a limited preview build..."    
     if [ -z "$CONTENT_DOC_NO_FETCH" ]; then
-        git fetch
+        git remote get-url origin || git remote add origin https://github.com/demisto/demisto-content.git
+        git remote -v
+        git fetch origin
     fi
     echo "HEAD ref $(git rev-parse HEAD). remotes/origin/master ref: $(git rev-parse master)"
     DIFF_FILES=$(git diff --name-only  remotes/origin/master...HEAD --)  # so we fail on errors if there is a problem

--- a/content-repo/create-docs.sh
+++ b/content-repo/create-docs.sh
@@ -100,7 +100,7 @@ if [[ "$PULL_REQUEST" == "true" && "$CONTENT_BRANCH" == "master" ]]; then
         git remote -v
         git fetch origin
     fi
-    echo "HEAD ref $(git rev-parse HEAD). remotes/origin/master ref: $(git rev-parse master)"
+    echo "HEAD ref $(git rev-parse HEAD). remotes/origin/master ref: $(git rev-parse remotes/origin/master)"
     DIFF_FILES=$(git diff --name-only  remotes/origin/master...HEAD --)  # so we fail on errors if there is a problem
     echo -e "Modified files:\n$DIFF_FILES\n-----------"    
     echo "$DIFF_FILES" | grep -v -E '^docs/' || MAX_FILES=20    

--- a/content-repo/create-docs.sh
+++ b/content-repo/create-docs.sh
@@ -95,8 +95,8 @@ cd ${SCRIPT_DIR}
 
 if [[ "$PULL_REQUEST" == "true" && "$CONTENT_BRANCH" == "master" ]]; then
     echo "Checking if only doc files where modified and we can do a limited preview build..."
-    git branch -a
-    DIFF_FILES=$(git diff --name-only  remotes/origin/HEAD...HEAD --)  # so we fail on errors if there is a problem
+    echo "HEAD ref $(git rev-parse HEAD). master ref: $(git rev-parse master)"
+    DIFF_FILES=$(git diff --name-only  master...HEAD --)  # so we fail on errors if there is a problem
     echo -e "Modified files:\n$DIFF_FILES\n-----------"    
     echo "$DIFF_FILES" | grep -v -E '^docs/' || MAX_FILES=20    
     if [ -n "$MAX_FILES" ]; then

--- a/content-repo/create-docs.sh
+++ b/content-repo/create-docs.sh
@@ -96,7 +96,7 @@ cd ${SCRIPT_DIR}
 if [[ "$PULL_REQUEST" == "true" && "$CONTENT_BRANCH" == "master" ]]; then
     echo "Checking if only doc files where modified and we can do a limited preview build..."    
     if [ -z "$CONTENT_DOC_NO_FETCH" ]; then
-        git remote get-url origin || git remote add origin https://github.com/demisto/demisto-content.git
+        git remote get-url origin || git remote add origin https://github.com/demisto/content-docs.git
         git remote -v
         git fetch origin
     fi

--- a/content-repo/create-docs.sh
+++ b/content-repo/create-docs.sh
@@ -95,8 +95,12 @@ cd ${SCRIPT_DIR}
 
 if [[ "$PULL_REQUEST" == "true" && "$CONTENT_BRANCH" == "master" ]]; then
     echo "Checking if only doc files where modified and we can do a limited preview build..."
-    echo "HEAD ref $(git rev-parse HEAD). master ref: $(git rev-parse master)"
-    DIFF_FILES=$(git diff --name-only  master...HEAD --)  # so we fail on errors if there is a problem
+    git remote -v
+    if [ -z "$CONTENT_DOC_NO_FETCH" ]; then
+        git fetch
+    fi
+    echo "HEAD ref $(git rev-parse HEAD). remotes/origin/master ref: $(git rev-parse master)"
+    DIFF_FILES=$(git diff --name-only  remotes/origin/master...HEAD --)  # so we fail on errors if there is a problem
     echo -e "Modified files:\n$DIFF_FILES\n-----------"    
     echo "$DIFF_FILES" | grep -v -E '^docs/' || MAX_FILES=20    
     if [ -n "$MAX_FILES" ]; then

--- a/content-repo/create-docs.sh
+++ b/content-repo/create-docs.sh
@@ -95,7 +95,8 @@ cd ${SCRIPT_DIR}
 
 if [[ "$PULL_REQUEST" == "true" && "$CONTENT_BRANCH" == "master" ]]; then
     echo "Checking if only doc files where modified and we can do a limited preview build..."
-    DIFF_FILES=$(git diff --name-only  remotes/origin/master...HEAD --)  # so we fail on errors if there is a problem
+    git branch -a
+    DIFF_FILES=$(git diff --name-only  remotes/origin/HEAD...HEAD --)  # so we fail on errors if there is a problem
     echo -e "Modified files:\n$DIFF_FILES\n-----------"    
     echo "$DIFF_FILES" | grep -v -E '^docs/' || MAX_FILES=20    
     if [ -n "$MAX_FILES" ]; then

--- a/content-repo/create-docs.sh
+++ b/content-repo/create-docs.sh
@@ -95,7 +95,7 @@ cd ${SCRIPT_DIR}
 
 if [[ "$PULL_REQUEST" == "true" && "$CONTENT_BRANCH" == "master" ]]; then
     echo "Checking if only doc files where modified and we can do a limited preview build..."
-    DIFF_FILES=$(git diff --name-only  origin/master...HEAD)  # so we fail on errors if there is a problem
+    DIFF_FILES=$(git diff --name-only  remotes/origin/master...HEAD --)  # so we fail on errors if there is a problem
     echo -e "Modified files:\n$DIFF_FILES\n-----------"    
     echo "$DIFF_FILES" | grep -v -E '^docs/' || MAX_FILES=20    
     if [ -n "$MAX_FILES" ]; then

--- a/content-repo/gendocs.py
+++ b/content-repo/gendocs.py
@@ -200,10 +200,10 @@ def create_docs(content_dir: str, target_dir: str, regex_list: List[str], prefix
     readme_files = findfiles(regex_list, content_dir)
     print(f'Processing: {len(readme_files)} {prefix} files ...')
     if MAX_FILES > 0:
-        print(f'DEV MODE. Truncating file list to: {MAX_FILES}')
+        print(f'PREVIEW MODE. Truncating file list to: {MAX_FILES}')
         readme_files = readme_files[:MAX_FILES]
     if FILE_REGEX:
-        print(f'DEV MODE. Matching only files which match: {FILE_REGEX}')
+        print(f'PREVIEW MODE. Matching only files which match: {FILE_REGEX}')
         regex = re.compile(FILE_REGEX)
         readme_files = list(filter(regex.search, readme_files))
     target_sub_dir = f'{target_dir}/{prefix}'
@@ -255,6 +255,8 @@ def main():
     index_target = args.target + '/index.md'
     shutil.copy(index_base, index_target)
     with open(index_target, 'a', encoding='utf-8') as f:
+        if MAX_FILES > 0:
+            f.write(f'\n\n# =====<br/>BUILD PREVIEW only {MAX_FILES} files from each category! <br/>=====\n\n')
         f.write("\n\n## Integrations\n\n")
         f.write(index_doc_infos(integration_doc_infos, INTEGRATIONS_PREFIX))
         f.write("\n\n## Playbooks\n\n")


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Status
Ready

## Related Issues
fixes: link to the issue

## Description
When building a PR preview and there is no matching branch we generate a smaller reference doc build with only 20 files if the only modifications are in the docs dir. 

Note that this build will still generate a full reference as it includes modifications outside of the docs dir. Only after we merge to master will we see the effects of this.

## Screenshots
Paste here any images that will help the reviewer
