### PR TITLE
disable git-lfs when checking out content repo

### DIFF
--- a/content-repo/create-docs.sh
+++ b/content-repo/create-docs.sh
@@ -67,8 +67,11 @@ else
     fi
 
     if [ -n "${NETLIFY}" ]; then
-        echo "Deleting cached content dir..."
-        rm -rf "${CONTENT_GIT_DIR}"
+        if [[ -d ${CONTENT_GIT_DIR} ]]; then
+            echo "Content git dir cached size: $(du -sh ${CONTENT_GIT_DIR})"
+            echo "Deleting cached content dir..."
+            rm -rf "${CONTENT_GIT_DIR}"
+        fi
         echo "Setting git config"
         git config --global user.email "netlifybuild@demisto.com"
         git config --global user.name "Netlify Dev Docs Build"
@@ -98,6 +101,8 @@ else
         git checkout master
     fi
 fi
+
+echo "Content git dir [${CONTENT_GIT_DIR}] size: $(du -sh ${CONTENT_GIT_DIR})"
 
 cd ${SCRIPT_DIR}
 

--- a/content-repo/create-docs.sh
+++ b/content-repo/create-docs.sh
@@ -11,6 +11,8 @@ if [[ "${SCRIPT_DIR}" != /* ]]; then
     SCRIPT_DIR="${CURRENT_DIR}/${SCRIPT_DIR}"
 fi
 
+export GIT_LFS_SKIP_SMUDGE=1
+
 if [[ -n "$CONTENT_REPO_DIR" ]]; then
     CONTENT_GIT_DIR=$CONTENT_REPO_DIR
     echo "============== Local manual DEV MODE detected. ==================="


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Status
Ready

## Related Issues
fixes: link to the issue

## Description
We were checking out the content repo using git-lfs. This is now disabled as the files are not needed.

## Screenshots
Paste here any images that will help the reviewer
