### PR TITLE
Design Guidelines Edit - around command naming convention and indicator timeline 

### DIFF
--- a/docs/concepts/design-best-practices.md
+++ b/docs/concepts/design-best-practices.md
@@ -14,13 +14,13 @@ In this section we captured some of the Design Best practices that you should be
 - Add score thresholds and DBot score mapping to the integration documentation.
 - Add generic reputation commands such as “!url,ip,file,domain”.
 - Global Context outputs – Don’t forget global context outputs for DBot scoring and global indicators.
-- When adding or removing indicators, add a message to the indicator timeline. the message should be from example: **The indicator was added to XXX**. See [Demisto Results](code-conventions#deprecated---demistoresults).
+- When adding or removing indicators, add a message to the indicator timeline. The message should be something like the following: ***The indicator was added to XXX***. See [Demisto Results](code-conventions#deprecated---demistoresults).
 - Be sure to check the top [Use Cases](use-cases). If those are supported via api make sure to include them in the integration.
 - Time arguments – When the command supports filtering results by time, use start + end time parameters (if supported by UI), and a timeframe parameter, that accepts inputs such as “4 days ago”, “5 minutes ago”, etc.
 - The data you return should make sense to an analyst (convert Epoch timestamps, decrypt data if needed. If you return IDs, make sure to return the original asset name, category type, group name etc.)
 - Make sure the parameters and command descriptions are descriptive enough
 - Stay as true to your product as possible: keep the same names as used by your product, the UI is a good baseline for what the human readable should look like.
-- Stick to the naming convention of the commands: **PRODUCTNAME-OBJECTNAME-ACTION**. In this structure it is easier to find the right object in the UI.
+- Stick to the naming convention of the commands: ***PRODUCTNAME-OBJECTNAME-ACTION***. In this structure, it is easier to find the right object in the UI.
 - Context limitation – If the result can include a lot of data, limit the context size.
 - Polling playbook & check status command – If the command can take more than a few seconds (vulnerability scan, complex search, detonation, etc) make sure to add a polling playbook. If implemented, do remember to include a “status” command as well.
 - Backwards compatibility – Don’t break it. Few suggested workarounds: keep the old context, add new paths as needed and update the outputs accordingly, if a command needs major changes, deprecate it and add a new one

--- a/docs/concepts/design-best-practices.md
+++ b/docs/concepts/design-best-practices.md
@@ -14,7 +14,7 @@ In this section we captured some of the Design Best practices that you should be
 - Add score thresholds and DBot score mapping to the integration documentation.
 - Add generic reputation commands such as “!url,ip,file,domain”.
 - Global Context outputs – Don’t forget global context outputs for DBot scoring and global indicators.
-- When adding or removing indicators, add a message to the indicator timeline. the message should be from example: **The indicator XXX was added to XXX**. see [https://demisto.pan.dev/docs/integrations/code-conventions#deprecated---demistoresults](Demisto Results)
+- When adding or removing indicators, add a message to the indicator timeline. the message should be from example: **The indicator was added to XXX**. see [https://demisto.pan.dev/docs/integrations/code-conventions#deprecated---demistoresults](Demisto Results)
 - Be sure to check the top [Use Cases](use-cases). If those are supported via api make sure to include them in the integration.
 - Time arguments – When the command supports filtering results by time, use start + end time parameters (if supported by UI), and a timeframe parameter, that accepts inputs such as “4 days ago”, “5 minutes ago”, etc.
 - The data you return should make sense to an analyst (convert Epoch timestamps, decrypt data if needed. If you return IDs, make sure to return the original asset name, category type, group name etc.)

--- a/docs/concepts/design-best-practices.md
+++ b/docs/concepts/design-best-practices.md
@@ -14,7 +14,7 @@ In this section we captured some of the Design Best practices that you should be
 - Add score thresholds and DBot score mapping to the integration documentation.
 - Add generic reputation commands such as “!url,ip,file,domain”.
 - Global Context outputs – Don’t forget global context outputs for DBot scoring and global indicators.
-- When adding or removing indicators, add a message to the indicator timeline. the message should be from example: **The indicator was added to XXX**. see [https://demisto.pan.dev/docs/integrations/code-conventions#deprecated---demistoresults](Demisto Results)
+- When adding or removing indicators, add a message to the indicator timeline. the message should be from example: **The indicator was added to XXX**. see [Demisto Results](code-conventions#deprecated---demistoresults).
 - Be sure to check the top [Use Cases](use-cases). If those are supported via api make sure to include them in the integration.
 - Time arguments – When the command supports filtering results by time, use start + end time parameters (if supported by UI), and a timeframe parameter, that accepts inputs such as “4 days ago”, “5 minutes ago”, etc.
 - The data you return should make sense to an analyst (convert Epoch timestamps, decrypt data if needed. If you return IDs, make sure to return the original asset name, category type, group name etc.)

--- a/docs/concepts/design-best-practices.md
+++ b/docs/concepts/design-best-practices.md
@@ -14,11 +14,13 @@ In this section we captured some of the Design Best practices that you should be
 - Add score thresholds and DBot score mapping to the integration documentation.
 - Add generic reputation commands such as “!url,ip,file,domain”.
 - Global Context outputs – Don’t forget global context outputs for DBot scoring and global indicators.
+- When adding or removing indicators, add a message to the indicator timeline. the message should be from example: **The indicator XXX was added to XXX**. see [https://demisto.pan.dev/docs/integrations/code-conventions#deprecated---demistoresults](Demisto Results)
 - Be sure to check the top [Use Cases](use-cases). If those are supported via api make sure to include them in the integration.
 - Time arguments – When the command supports filtering results by time, use start + end time parameters (if supported by UI), and a timeframe parameter, that accepts inputs such as “4 days ago”, “5 minutes ago”, etc.
 - The data you return should make sense to an analyst (convert Epoch timestamps, decrypt data if needed. If you return IDs, make sure to return the original asset name, category type, group name etc.)
 - Make sure the parameters and command descriptions are descriptive enough
 - Stay as true to your product as possible: keep the same names as used by your product, the UI is a good baseline for what the human readable should look like.
+- Stick to the naming convention of the commands: **PRODUCTNAME-OBJECTNAME-ACTION**. in this structure it is easier to find the right object in the UI.
 - Context limitation – If the result can include a lot of data, limit the context size.
 - Polling playbook & check status command – If the command can take more than a few seconds (vulnerability scan, complex search, detonation, etc) make sure to add a polling playbook. If implemented, do remember to include a “status” command as well.
 - Backwards compatibility – Don’t break it. Few suggested workarounds: keep the old context, add new paths as needed and update the outputs accordingly, if a command needs major changes, deprecate it and add a new one

--- a/docs/concepts/design-best-practices.md
+++ b/docs/concepts/design-best-practices.md
@@ -14,13 +14,13 @@ In this section we captured some of the Design Best practices that you should be
 - Add score thresholds and DBot score mapping to the integration documentation.
 - Add generic reputation commands such as “!url,ip,file,domain”.
 - Global Context outputs – Don’t forget global context outputs for DBot scoring and global indicators.
-- When adding or removing indicators, add a message to the indicator timeline. the message should be from example: **The indicator was added to XXX**. see [Demisto Results](code-conventions#deprecated---demistoresults).
+- When adding or removing indicators, add a message to the indicator timeline. the message should be from example: **The indicator was added to XXX**. See [Demisto Results](code-conventions#deprecated---demistoresults).
 - Be sure to check the top [Use Cases](use-cases). If those are supported via api make sure to include them in the integration.
 - Time arguments – When the command supports filtering results by time, use start + end time parameters (if supported by UI), and a timeframe parameter, that accepts inputs such as “4 days ago”, “5 minutes ago”, etc.
 - The data you return should make sense to an analyst (convert Epoch timestamps, decrypt data if needed. If you return IDs, make sure to return the original asset name, category type, group name etc.)
 - Make sure the parameters and command descriptions are descriptive enough
 - Stay as true to your product as possible: keep the same names as used by your product, the UI is a good baseline for what the human readable should look like.
-- Stick to the naming convention of the commands: **PRODUCTNAME-OBJECTNAME-ACTION**. in this structure it is easier to find the right object in the UI.
+- Stick to the naming convention of the commands: **PRODUCTNAME-OBJECTNAME-ACTION**. In this structure it is easier to find the right object in the UI.
 - Context limitation – If the result can include a lot of data, limit the context size.
 - Polling playbook & check status command – If the command can take more than a few seconds (vulnerability scan, complex search, detonation, etc) make sure to add a polling playbook. If implemented, do remember to include a “status” command as well.
 - Backwards compatibility – Don’t break it. Few suggested workarounds: keep the old context, add new paths as needed and update the outputs accordingly, if a command needs major changes, deprecate it and add a new one


### PR DESCRIPTION

I've updated the design guidelines. 
- added the naming convention of the commands where we put the object first and then the action
- added the note about the indicator timeline. is the message clear? too simple? 

Guys go over it tell me what do you think, I would love your feedback. 

