### PR TITLE
Document ability to comment out sections of release notes.

### DIFF
--- a/docs/integrations/changelog.md
+++ b/docs/integrations/changelog.md
@@ -98,11 +98,17 @@ One should specify in the corresponding change log file the following changes:
   - Updating outputs
   - Fixes for customer bugs
   
-You may encounter a scenario where certain changes are not necessary to document in the release notes. To solve this, you may comment out the entries by using the following syntax:
+  
+## Excluding Items
+Release notes are required to contain all items which have been changed documented within them. As such, validation will fail if detected items are removed from the generated release notes file.
+
+However, you may encounter a scenario where certain changes are not necessary to document in the release notes. To solve this, you may comment out the entries by using the following syntax:
 
 ```markdown
 <!--
-Here's some hidden text.
+#### Integrations
+- __Cortex XDR - IR__
+  - Renamed an item. Not necessary to document in release notes.
 -->
 ```
 

--- a/docs/integrations/changelog.md
+++ b/docs/integrations/changelog.md
@@ -97,5 +97,13 @@ One should specify in the corresponding change log file the following changes:
   - Adding/updating arguments
   - Updating outputs
   - Fixes for customer bugs
+  
+You may encounter a scenario where certain changes are not necessary to document in the release notes. To solve this, you may comment out the entries by using the following syntax:
+
+```markdown
+<!--
+Here's some hidden text.
+-->
+```
 
 To view the previous format for release notes, you may find them [here.](../integrations/changelog-old-format)

--- a/docs/integrations/changelog.md
+++ b/docs/integrations/changelog.md
@@ -100,7 +100,7 @@ One should specify in the corresponding change log file the following changes:
   
   
 ## Excluding Items
-Release notes are required to contain all items which have been changed documented within them. As such, validation will fail if detected items are removed from the generated release notes file.
+Release notes are required to contain all items which have been changed included in the generated file. As such, validation will fail if detected items are removed from the generated release notes file.
 
 However, you may encounter a scenario where certain changes are not necessary to document in the release notes. To solve this, you may comment out the entries by using the following syntax:
 


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Status
Ready

## Related Issues
fixes: Internal change to documentation procedure

## Description
Documented the ability to comment out sections of release notes.