### PR TITLE
Ref docs: change escaping logic for name. only do html escape when on page

### DIFF
--- a/content-repo/gendocs.py
+++ b/content-repo/gendocs.py
@@ -130,7 +130,6 @@ def process_readme_doc(target_dir: str, content_dir: str, readme_file: str) -> D
         id = yml_data.get('commonfields', {}).get('id') or yml_data['id']
         id = normalize_id(id)
         name = yml_data.get('display') or yml_data['name']
-        name = html.escape(name)
         desc = yml_data.get('description') or yml_data.get('comment')
         if desc:
             word_break = False
@@ -158,7 +157,7 @@ def process_readme_doc(target_dir: str, content_dir: str, readme_file: str) -> D
             if readme_repo_path.startswith(content_dir):
                 readme_repo_path = readme_repo_path[len(content_dir):]
             edit_url = f'https://github.com/demisto/content/blob/{BRANCH}/{readme_repo_path}'
-            content = f'---\nid: {id}\ntitle: "{doc_info.name}"\ncustom_edit_url: {edit_url}\n---\n\n' + content
+            content = f'---\nid: {id}\ntitle: {json.dumps(doc_info.name)}\ncustom_edit_url: {edit_url}\n---\n\n' + content
         verify_mdx_server(content)
         with open(f'{target_dir}/{id}.md', mode='w', encoding='utf-8') as f:  # type: ignore
             f.write(content)
@@ -207,8 +206,9 @@ def index_doc_infos(doc_infos: List[DocInfo], link_prefix: str, headers: Optiona
         return ''
     table_items = []
     for d in doc_infos:
-        link_name = f'[{d.name}]({link_prefix}/{d.id})'
-        for word in re.split(r'\s|-', d.name):
+        name = html.escape(d.name)
+        link_name = f'[{name}]({link_prefix}/{d.id})'
+        for word in re.split(r'\s|-', name):
             if len(word) > 25:  # we have a long word tell browser ok to break it
                 link_name = '<span style={{wordBreak: "break-word"}}>' + link_name + '</span>'
                 break


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Status
Ready

## Related Issues
fixes: link to the issue

## Description
Fix the way we escape the name of ref pages

## Screenshots
Before:
![image](https://user-images.githubusercontent.com/1395797/82905505-a31b9680-9f6c-11ea-9409-6866ba55d796.png)

After: 
![image](https://user-images.githubusercontent.com/1395797/82905535-aca4fe80-9f6c-11ea-86cb-d207bbc80f89.png)
