### PR TITLE
fix(search): remove wrong usage of filter

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -17,7 +17,7 @@ module.exports = {
     algolia: {
       apiKey: process.env.ALGOLIA_APIKEY,
       indexName: process.env.ALGOLIA_INDEX,
-      algoliaOptions: { typoTolerance: false, hitsPerPage: 1000, filters: 'anchor:"__docusaurus"' } // Optional, if provided by Algolia
+      algoliaOptions: { typoTolerance: false, hitsPerPage: 1000 } // Optional, if provided by Algolia
     },
     sidebarCollapsible: true,
     navbar: {


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Status
Ready

## Related Issues
fixes: search issue

## Description
Removing a wrong usage of filter. There is no point to filter on anchors.

__docusaurus anchors are not indexed anymore thanks to https://github.com/algolia/docsearch-scraper/pull/505