### PR TITLE
Filter search results by type/hierarchy

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -17,7 +17,7 @@ module.exports = {
     algolia: {
       apiKey: "f5dfbee43cfa4c5024b10045c6d91461",
       indexName: "demisto",
-      algoliaOptions: { typoTolerance: false, hitsPerPage: 1000 } // Optional, if provided by Algolia
+      algoliaOptions: { typoTolerance: false, hitsPerPage: 1000, filters: 'type:lvl1' } // Optional, if provided by Algolia
     },
     sidebarCollapsible: true,
     navbar: {


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Status
Ready

## Related Issues
n/a

## Description
Filters Algolia search results by `type` attribute which represents what hierarchy the search result occupies on a doc page. The goal is to help narrow the search results by excluding subheadings.

@glicht please test and provide feedback.

Note: The `type` attribute was added as a filterable facet in preparation for this pull request. 

## Screenshots
Paste here any images that will help the reviewer
