### PR TITLE
Add type:content to search filter

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -17,7 +17,7 @@ module.exports = {
     algolia: {
       apiKey: "f5dfbee43cfa4c5024b10045c6d91461",
       indexName: "demisto",
-      algoliaOptions: { typoTolerance: false, hitsPerPage: 1000, filters: 'type:lvl1' } // Optional, if provided by Algolia
+      algoliaOptions: { typoTolerance: false, hitsPerPage: 1000, filters: 'type:lvl1 OR type:content' } // Optional, if provided by Algolia
     },
     sidebarCollapsible: true,
     navbar: {


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Status
Ready

## Related Issues
n/a

## Description
Allow results matching `type:content` to appear in search results. Please note that this change could result in many more hits.

## Screenshots
<img width="522" alt="Screen Shot 2020-06-29 at 9 36 17 AM" src="https://user-images.githubusercontent.com/9343811/86021192-74229580-b9ee-11ea-91ea-16107f7e1bfc.png">

