### PR TITLE
add "Deprecated" callout to content from Packs/DeprecatedContent

### DIFF
--- a/content-repo/gendocs.py
+++ b/content-repo/gendocs.py
@@ -116,7 +116,7 @@ def gen_html_doc(txt: str) -> str:
 
 
 def get_deprecated_data(yml_data: dict, desc: str, readme_file: str):
-    if yml_data.get('deprecated') or 'DeprecatedContent' in readme_file:
+    if yml_data.get('deprecated') or 'DeprecatedContent' in readme_file or yml_data.get('hidden'):
         dep_msg = ""
         dep_match = re.match(r'deprecated\s*[\.\-:]\s*(.*?)\.', desc, re.IGNORECASE)
         if dep_match and 'instead' in dep_match[1]:

--- a/content-repo/gendocs.py
+++ b/content-repo/gendocs.py
@@ -115,11 +115,11 @@ def gen_html_doc(txt: str) -> str:
             '<div dangerouslySetInnerHTML={{__html: txt}} />\n')
 
 
-def get_deprecated_data(yml_data: dict, desc: str):
-    if yml_data.get('deprecated'):
+def get_deprecated_data(yml_data: dict, desc: str, readme_file: str):
+    if yml_data.get('deprecated') or 'DeprecatedContent' in readme_file:
         dep_msg = ""
         dep_match = re.match(r'deprecated\s*[\.\-:]\s*(.*?)\.', desc, re.IGNORECASE)
-        if dep_match:
+        if dep_match and 'instead' in dep_match[1]:
             dep_msg = dep_match[1] + '\n'
         return f':::caution Deprecated\n{dep_msg}:::\n\n'
     return ""
@@ -183,7 +183,7 @@ def process_readme_doc(target_dir: str, content_dir: str, readme_file: str) -> D
                 readme_repo_path = readme_repo_path[len(content_dir):]
             edit_url = f'https://github.com/demisto/content/blob/{BRANCH}/{readme_repo_path}'
             header = f'---\nid: {id}\ntitle: {json.dumps(doc_info.name)}\ncustom_edit_url: {edit_url}\n---\n\n'
-            content = get_deprecated_data(yml_data, desc) + content
+            content = get_deprecated_data(yml_data, desc, readme_file) + content
             content = get_beta_data(yml_data, content) + content
             content = header + content
         verify_mdx_server(content)

--- a/content-repo/gendocs_test.py
+++ b/content-repo/gendocs_test.py
@@ -170,10 +170,12 @@ def test_process_extra_doc(tmp_path, mdx_server):
 
 
 def test_get_deprecated_data():
-    res = get_deprecated_data({"deprecated": True}, "Deprecated - We recommend using ServiceNow v2 instead.")
+    res = get_deprecated_data({"deprecated": True}, "Deprecated - We recommend using ServiceNow v2 instead.", "README.md")
     assert "We recommend using ServiceNow v2 instead" in res
-    assert get_deprecated_data({"deprecated": False}, "stam") == ""
-    res = get_deprecated_data({"deprecated": True}, "Deprecated: use Shodan v2 instead. Search engine for Internet-connected devices.")
+    assert get_deprecated_data({"deprecated": False}, "stam", "README.md") == ""
+    res = get_deprecated_data({"deprecated": True}, "Deprecated: use Shodan v2 instead. Search engine for Internet-connected devices.", "README.md")
     assert "use Shodan v2 instead" in res
-    res = get_deprecated_data({"deprecated": True}, "Deprecated. Use The Generic SQL integration instead.")
+    res = get_deprecated_data({"deprecated": True}, "Deprecated. Use The Generic SQL integration instead.", "README.md")
     assert "Use The Generic SQL integration instead" in res
+    res = get_deprecated_data({}, "Deprecated. Add information about the vulnerability.", "Packs/DeprecatedContent/Playbooks/test-README.md")
+    assert "Add information" not in res


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Status
Ready

## Related Issues
fixes: link to the issue

## Description
Any content in DeprecatedContent will get a "Deprecated" callout. Mostly relevant for playbooks that don't have the yml setting of deprecated.

## Screenshots
![image](https://user-images.githubusercontent.com/1395797/87607069-294e9080-c705-11ea-861a-2629a69f1370.png)
