### PR TITLE
reducing the header size of the compatibility message

### DIFF
--- a/content-repo/extra-docs/releases/20.7.1.md
+++ b/content-repo/extra-docs/releases/20.7.1.md
@@ -5,8 +5,7 @@
 
 Welcome to the 20.7.1 Content Release for Cortex XSOAR. Starting from the 20.6.0 release, we restructured our release notes to be based on **Content Packs**. One of our team's top priorities is making our Content more accessible and understandable for both users and contributors. In this effort, we recently moved our [Content repo](https://github.com/demisto/content) to work in Pack format, in which there is a clear separation and grouping of Content artifacts. Each Content Pack provides a clear grouping of related Content artifacts used to either implement a use case, implement an integration or provide a clear set of functionality. Our new release notes are structured around Content Packs and you will see related Content artifacts grouped together according to Packs. We hope you will find this new format useful and clear.
 
-For Cortex XSOAR version 5.5 and earlier, you can still install content updates directly in the platform. 
----
+#### For Cortex XSOAR version 5.5 and earlier, you can still install content updates directly in the platform. 
 
 ### End Of Life Notice 
 The following integrations were deprecated in November 2019:  


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Status
Ready

## Related Issues
fixes: link to the issue

## Description
A few sentences describing the overall goals of the pull request's commits.

## Screenshots
The header of the compatibility message was too big:
![image](https://user-images.githubusercontent.com/1395797/88086405-005c4e80-cb90-11ea-9996-f4d3e719e856.png)


