### PR TITLE
add announcment bar for github star

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -141,6 +141,13 @@ module.exports = {
         // href: "https://pan.dev"
       },
       copyright: `Copyright © ${new Date().getFullYear()} Palo Alto Networks, Inc.`
+    },
+    announcementBar: {
+      id: 'github_star',
+      content:
+        '⭐️ If you like Cortex XSOAR Content, give it a star on <a target="_blank" rel="noopener noreferrer" href="https://github.com/demisto/content">GitHub</a>! ⭐',
+      backgroundColor: '#fafbfc',
+      textColor: '#091E42',
     }
   },
   themes: ["@docusaurus/theme-live-codeblock"],


### PR DESCRIPTION

## Status
Ready

## Description
Added announcement bar at the top of the page to point to the content repo to star it (if they like it)

## Screenshots
![image](https://user-images.githubusercontent.com/31018228/92081224-6e20aa80-edcb-11ea-8e79-6ee87ee82a60.png)

