### PR TITLE
Simplify server layout

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "start": "docusaurus start",
     "heapstats": "node -e 'console.log(\"Node heap stats: \", v8.getHeapStatistics())'",
     "build-docusaurus": "cp -RPv docs/doc_imgs/* static/doc_imgs/ && replace '(\\.\\.\\/){0,2}(../docs/)?doc_imgs' '/doc_imgs' docs/* --include='*.md*' --recursive && docusaurus build",
-    "build": "npm run reference-docs && npm run heapstats && npm run build-docusaurus",
+    "build": "time npm run reference-docs && npm run heapstats && time npm run build-docusaurus",
     "findorphans": "for i in `cd docs && find . -name '*.md' | cut -d '.' -f2 | cut -d'/' -f2-`; do grep $i sidebars.js 1>/dev/null || echo \"Document not in sidebar: $i\"; done",
     "swizzle": "docusaurus swizzle",
     "deploy": "docusaurus deploy",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "start": "docusaurus start",
     "heapstats": "node -e 'console.log(\"Node heap stats: \", v8.getHeapStatistics())'",
     "build-docusaurus": "cp -RPv docs/doc_imgs/* static/doc_imgs/ && replace '(\\.\\.\\/){0,2}(../docs/)?doc_imgs' '/doc_imgs' docs/* --include='*.md*' --recursive && docusaurus build",
-    "build": "time npm run reference-docs && npm run heapstats && time npm run build-docusaurus",
+    "build": "npm run reference-docs && npm run heapstats && npm run build-docusaurus",
     "findorphans": "for i in `cd docs && find . -name '*.md' | cut -d '.' -f2 | cut -d'/' -f2-`; do grep $i sidebars.js 1>/dev/null || echo \"Document not in sidebar: $i\"; done",
     "swizzle": "docusaurus swizzle",
     "deploy": "docusaurus deploy",

--- a/src/theme/DocPage/index.js
+++ b/src/theme/DocPage/index.js
@@ -1,0 +1,64 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import React from 'react';
+import {MDXProvider} from '@mdx-js/react';
+
+import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
+import renderRoutes from '@docusaurus/renderRoutes';
+import Layout from '@theme/Layout';
+import DocSidebar from '@theme/DocSidebar';
+import MDXComponents from '@theme/MDXComponents';
+import NotFound from '@theme/NotFound';
+import {matchPath} from '@docusaurus/router';
+
+import styles from './styles.module.css';
+
+function DocPage(props) {
+  const {route: baseRoute, docsMetadata, location} = props;
+  // case-sensitive route such as it is defined in the sidebar
+  const currentRoute =
+    baseRoute.routes.find((route) => {
+      return matchPath(location.pathname, route);
+    }) || {};
+  const {permalinkToSidebar, docsSidebars, version} = docsMetadata;
+  const sidebar = permalinkToSidebar[currentRoute.path];
+  const {
+    siteConfig: {themeConfig = {}} = {},
+    isClient,
+  } = useDocusaurusContext();
+
+  const {sidebarCollapsible = true} = themeConfig;
+
+  if (Object.keys(currentRoute).length === 0) {
+    return <NotFound {...props} />;
+  }
+
+  return (
+    <Layout version={version} key={isClient}>
+      <div className={styles.docPage}>
+        {sidebar && isClient && (
+          <div className={styles.docSidebarContainer} role="complementary">
+            <DocSidebar
+              docsSidebars={docsSidebars}
+              path={currentRoute.path}
+              sidebar={sidebar}
+              sidebarCollapsible={sidebarCollapsible}
+            />
+          </div>
+        )}
+        <main className={styles.docMainContainer}>
+          <MDXProvider components={MDXComponents}>
+            {renderRoutes(baseRoute.routes)}
+          </MDXProvider>
+        </main>
+      </div>
+    </Layout>
+  );
+}
+
+export default DocPage;

--- a/src/theme/DocPage/styles.module.css
+++ b/src/theme/DocPage/styles.module.css
@@ -1,0 +1,32 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+.docPage {
+  display: flex;
+}
+
+.docSidebarContainer {
+  border-right: 1px solid var(--ifm-toc-border-color);
+  box-sizing: border-box;
+  width: 300px;
+  position: relative;
+  margin-top: calc(-1 * var(--ifm-navbar-height));
+}
+
+.docMainContainer {
+  flex-grow: 1;
+}
+
+@media (max-width: 996px) {
+  .docPage {
+    display: inherit;
+  }
+
+  .docSidebarContainer {
+    margin-top: 0;
+  }
+}


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Status
In Progress

## Related Issues
Slow build time of xsoar.pan.dev

## Description
Docusaurus v2 dumps the full content of the sidebar in every client JS component and in every server html file. This PR customize the DocPage component to dump the sidebar only inside the client JS components and not in server html files. This provides a good speedup in build time, with the only inconvenience of a little lag in sidebar loading when following a direct deep link.

