### PR TITLE
Remove markdown p color CSS override

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -74,11 +74,6 @@ html[data-theme="dark"] {
   --ifm-footer-background-color: #000;
 }
 
-/* Docs overrides */
-.markdown p {
-  color: var(--ifm-color-gray-800) !important;
-}
-
 blockquote {
   border-left: 10px solid var(--ifm-color-primary) !important;
   border-top: 1px solid var(--ifm-color-primary) !important;


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Status
Ready

## Related Issues
n/a

## Description

Note admonition p text in dark mode was illegible due to CSS override. This solution introduces a slight change in text color throughout the site but there isn't a more specific CSS variable that covers admonition body text styling. Please review and let me know if you're ok with the changes.

## Screenshots

Before:
 
![image](https://user-images.githubusercontent.com/9343811/93132032-9a290f00-f69a-11ea-8af3-f9e9b2021eee.png)

After:

![Screen Shot 2020-09-14 at 2 58 07 PM](https://user-images.githubusercontent.com/9343811/93132138-c5abf980-f69a-11ea-976f-10f8b6e9c3a1.png)
