### PR TITLE
Update fetching-incidents.md

### DIFF
--- a/docs/integrations/fetching-incidents.md
+++ b/docs/integrations/fetching-incidents.md
@@ -50,7 +50,7 @@ The following example shows how we use both **First Run** and the **Query** opti
 
     day_ago = datetime.now() - timedelta(days=1) 
     start_time = day_ago.time()
-    if last_run and last_run.has_key('start_time'):
+    if last_run and 'start_time' in last_run:
         start_time = last_run.get('start_time')
 
     # execute the query and get the events


### PR DESCRIPTION
python dictionary has_key() was removed in Python 3.x https://docs.python.org/3.1/whatsnew/3.0.html#builtins

using in operator is preferred. And as Python 2.x is deprecated we should show examples in python 3.x

<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Status
Ready

## Description
Change to Python 3.x notation


