### PR TITLE
Added .pack-ignore documentation

### DIFF
--- a/docs/integrations/fetching-incidents.md
+++ b/docs/integrations/fetching-incidents.md
@@ -50,7 +50,7 @@ The following example shows how we use both **First Run** and the **Query** opti
 
     day_ago = datetime.now() - timedelta(days=1) 
     start_time = day_ago.time()
-    if last_run and last_run.has_key('start_time'):
+    if last_run and 'start_time' in last_run:
         start_time = last_run.get('start_time')
 
     # execute the query and get the events

--- a/docs/integrations/packs-format.md
+++ b/docs/integrations/packs-format.md
@@ -136,3 +136,21 @@ This file will be used while running the `demisto-sdk secrets`([explanation](htt
  use it as a  white list of approved words for your PR.
 
 **Note**: We use `demisto-sdk secrets` as part of our pre-commit hook to check that possible secrets in the PR aren't exposed to a public repository.
+
+### .pack-ignore
+This file allows ignoring linter errors while lint checking, and ignoring tests in the test collection.
+
+To add ignored tests / linter errors in a file, first add the file name to the **.pack-ignore** in this format
+```
+[file:integration-to-ignore.yml]
+```
+
+On the following line add `ignore=` flag, with one or more comma separated values:
+1. `auto-test` - ignore test file in the build test collection.
+2. `linter code` e.g. IN126 - ignore linter error codes.
+
+#### Example .pack-ignore
+```
+[file:playbook-Special-Test-Not-To-Run-Directly.yml]
+ignore=IN126,auto-test
+```

--- a/docs/integrations/packs-format.md
+++ b/docs/integrations/packs-format.md
@@ -138,19 +138,22 @@ This file will be used while running the `demisto-sdk secrets`([explanation](htt
 **Note**: We use `demisto-sdk secrets` as part of our pre-commit hook to check that possible secrets in the PR aren't exposed to a public repository.
 
 ### .pack-ignore
-This file allows ignoring linter errors while lint checking, and ignoring tests in the test collection.
+This file allows ignoring linter errors while lint checking and ignoring tests in the test collection.
 
-To add ignored tests / linter errors in a file, first add the file name to the **.pack-ignore** in this format
+To add ignored tests/linter errors in a file, first, add the file name to the **.pack-ignore** in this format
 ```
 [file:integration-to-ignore.yml]
 ```
 
-On the following line add `ignore=` flag, with one or more comma separated values:
+On the following line add `ignore=` flag, with one or more comma-separated values:
 1. `auto-test` - ignore test file in the build test collection.
 2. `linter code` e.g. IN126 - ignore linter error codes.
 
 #### Example .pack-ignore
 ```
 [file:playbook-Special-Test-Not-To-Run-Directly.yml]
-ignore=IN126,auto-test
+ignore=auto-test
+
+[file:integration-to-ignore.yml]
+ignore=IN126,PA116
 ```


### PR DESCRIPTION
## Status
Ready

## Description
Added .pack-ignore documentation

## Docs addition:

### .pack-ignore
This file allows ignoring linter errors while lint checking and ignoring tests in the test collection.

To add ignored tests/linter errors in a file, first, add the file name to the **.pack-ignore** in this format
```
[file:integration-to-ignore.yml]
```

On the following line add `ignore=` flag, with one or more comma-separated values:
1. `auto-test` - ignore test file in the build test collection.
2. `linter code` e.g. IN126 - ignore linter error codes.

#### Example .pack-ignore
```
[file:playbook-Special-Test-Not-To-Run-Directly.yml]
ignore=auto-test

[file:integration-to-ignore.yml]
ignore=IN126,PA116
```

