### PR TITLE
Deprecated CommandResults.indicators and added CommandResults.indicator

### DIFF
--- a/docs/integrations/code-conventions.md
+++ b/docs/integrations/code-conventions.md
@@ -647,7 +647,8 @@ This class is used to return outputs. This object represents an entry in warroom
 | outputs           | object | The data to be returned and will be set to context                                                                                                                                         |
 | readable_output    | str   | (Optional) markdown string that will be presented in the warroom, should be human readable -  (HumanReadable) - if not set, readable output will be generated via tableToMarkdown function |
 | raw_response      | object | (Optional) must be dictionary, if not provided then will be equal to outputs.  Usually must be the original raw response from the 3rd party service (originally Contents)                  |
-| indicators        | list   | Must be list of Indicator types, like Common.IP, Common.URL, Common.File, Common.Domain, Common.CVE.                                                                                       |
+| indicators        | list   | DEPRECATED: use 'indicator' instead.                                                                                                                                                       |
+| indicator         | Common.Indicator | single indicator like Common.IP, Common.URL, Common.File, etc.                                                                                                                   |
 | indicators_timeline | IndicatorsTimeline | Must be an IndicatorsTimeline. used by the server to populate an indicator's timeline.                                                                                       |
 
 **Example**
@@ -666,7 +667,7 @@ return_results(results)
 __Note:__ More examples on how to return results, [here](context-and-outputs)
 
 ### return_results
-```return_results()``` calls `demisto.results()`. It accept `CommandResults` object or any object that `demisto.results` 
+```return_results()``` calls `demisto.results()`. It accept either a list or single item of `CommandResults` object or any object that `demisto.results` 
 can accept.
 Use `return_results` to return mainly `CommandResults` object or basic `string`.
 
@@ -685,6 +686,27 @@ return_results(results)
 
 ```python
 return_results('Hello World')
+```
+
+```python
+results = [
+    CommandResults(
+        outputs_prefix='VirusTotal.IP',
+        outputs_key_field='Address',
+        outputs={
+            'Address': '8.8.8.8',
+            'ASN': 12345
+        }
+    ), 
+    CommandResults(
+        outputs_prefix='VirusTotal.IP',
+        outputs_key_field='Address',
+        outputs={
+            'Address': '1.1.1.1',
+            'ASN': 67890
+        }
+    )]
+return_results(results)
 ```
 
 __Note:__ More examples on how to return results, [here](context-and-outputs)

--- a/docs/integrations/context-and-outputs.md
+++ b/docs/integrations/context-and-outputs.md
@@ -358,7 +358,7 @@ results = CommandResults(
     outputs_prefix='Autofocus.IP',
     outputs_key_field='indicator',
     outputs=ip_reputation_from_autofocus,
-    indicators=[ip]
+    indicator=ip
 )
 
 return_results(results)
@@ -475,7 +475,7 @@ results = CommandResults(
     outputs_prefix='Autofocus.Domain',
     outputs_key_field='domain',
     outputs=domain_raw,
-    indicators=[domain]
+    indicator=domain
 )
 
 return_results(results)
@@ -744,7 +744,7 @@ results = CommandResults(
     outputs_prefix='VirusTotal.URL',
     outputs_key_field='url',
     outputs=url_raw_response,
-    indicators=[url]
+    indicator=url
 )
 
 return_results(results)
@@ -873,7 +873,7 @@ results = CommandResults(
     outputs_prefix='VirusTotal.File',
     outputs_key_field='md5',
     outputs=hash_reputation_response,
-    indicators=[file]
+    indicator=file
 )
 
 return_results(results)
@@ -1016,7 +1016,7 @@ results = CommandResults(
     outputs_prefix='CVEMitre.CVE',
     outputs_key_field='id',
     outputs=cve_raw_response,
-    indicators=[cve]
+    indicator=cve
 )
 
 return_results(results)


### PR DESCRIPTION
## Status
Ready

## Description
Updated descriptions to match new `CommandResults.indicator` changes, and emphasized `return_results` support for list of `CommandResults`.
