### PR TITLE
Update mirroring.md - incident IDs returned by get-modified-remote-data must be of type str

### DIFF
--- a/docs/integrations/mirroring.md
+++ b/docs/integrations/mirroring.md
@@ -90,9 +90,9 @@ def get_remote_data_command(client, args):
 * **GetModifiedRemoteDataArgs** - this is an object created to maintain all the arguments you receive from the server in order to use this command.
 Arguments explanation:
   - *last_update* - Date string represents the last time we retrieved modified incidents for this integration.
-* **GetModifiedRemoteDataResponse** - this is the object that maintains the format in which you should order the results from this function. You should use `return_results` on this object to make it work. 
+* **GetModifiedRemoteDataResponse** - this is the object that maintains the format in which you should order the results from this function. You should use `return_results` on this object to make it work.
 Arguments explanation. **You must provide one of the following:**
-  - *modified_incident_ids* - a list of incidents that were modified since the last check. Later `get-remote-data` command will run on only modified incidents.
+  - *modified_incident_ids* - a list of the IDs of the incidents that were modified since the last check. IDs must be of type string. Later `get-remote-data` command will run on only modified incidents.
   - *modified_incident_entries* - a list of entries containing the full incident data. In this case, `get-remote-data` **will not be called**.
 * **skip update** - in case of failure, in order to notify the server that the command failed and prevent execution of **get-remote-data** commands, return error which contains the string `"skip update"`.
 

--- a/docs/integrations/mirroring.md
+++ b/docs/integrations/mirroring.md
@@ -92,7 +92,7 @@ Arguments explanation:
   - *last_update* - Date string represents the last time we retrieved modified incidents for this integration.
 * **GetModifiedRemoteDataResponse** - this is the object that maintains the format in which you should order the results from this function. You should use `return_results` on this object to make it work.
 Arguments explanation. **You must provide one of the following:**
-  - *modified_incident_ids* - a list of the IDs of the incidents that were modified since the last check. IDs must be of type string. Later `get-remote-data` command will run on only modified incidents.
+  - *modified_incident_ids* - a list of strings representing incident IDs that were modified since the last check. Later `get-remote-data` command will run on only modified incidents.
   - *modified_incident_entries* - a list of entries containing the full incident data. In this case, `get-remote-data` **will not be called**.
 * **skip update** - in case of failure, in order to notify the server that the command failed and prevent execution of **get-remote-data** commands, return error which contains the string `"skip update"`.
 


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Status
Ready

## Description
Adding a note regarding incident IDs returned by get-modified-remote-data.
Currently only incident IDs of type string are supported, therefore added a note
for it so developers reading this doc will know s/he needs to transform IDs to string
in case they are not string in order for get-modified-remote-data to work properly.