### PR TITLE
Start slice index at 0 instead of 1

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -28,7 +28,7 @@ function genMetaData() {
   });
   if (process.env.MAX_PACKS) {
     console.log(`limiting packs to ${process.env.MAX_PACKS}`);
-    return marketplace.slice(1, process.env.MAX_PACKS);
+    return marketplace.slice(0, process.env.MAX_PACKS);
   }
   return marketplace;
 }

--- a/genPackDetails.js
+++ b/genPackDetails.js
@@ -92,7 +92,7 @@ function genPackDetails() {
   });
   if (process.env.MAX_PACKS) {
     console.log(`limiting packs to ${process.env.MAX_PACKS}`);
-    marketplace.slice(1, process.env.MAX_PACKS).map((pack) => {
+    marketplace.slice(0, process.env.MAX_PACKS).map((pack) => {
       if (pack.contentItems) {
         for (const [key, value] of Object.entries(pack.contentItems)) {
           for (const listItem of value) {


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Status
Ready

## Related Issues
fixes: link to the issue

## Description
Start slice index at 0 instead of 1 to ensure `MAX_PACKS` results in accurate number of packs built.

## Screenshots
Paste here any images that will help the reviewer
