### PR TITLE
sidebar: browser only rendering

### DIFF
--- a/src/theme/DocSidebar/index.js
+++ b/src/theme/DocSidebar/index.js
@@ -1,0 +1,17 @@
+import React from 'react';
+import BrowserOnly from '@docusaurus/BrowserOnly';
+import DocSidebar from '@theme-original/DocSidebar';
+
+function DocSidebarBrowser(props) {
+  return (
+    <BrowserOnly
+      fallback={<div>Sidebar...</div>}>
+      {() => {
+        // Something that should be excluded during build process prerendering.
+        return <DocSidebar {...props} />
+      }}
+    </BrowserOnly>
+  );
+}
+
+export default DocSidebarBrowser;


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Status
Ready

## Related Issues
fixes: link to the issue

## Description
Moved the siidebar to browser only rendering. The sidebar is not really needed for SEO and doing this improves the build by about 12 minutes. It does introduce a small delay (around 1 sec) until the sidebar is rendered in reference pages on first access. 

@sserrata @csestito please provide your feedback

## Screenshots
Paste here any images that will help the reviewer
