### PR TITLE
Use brand palette for secondary color and fix markdown table formatting

### DIFF
--- a/genMarketplace.js
+++ b/genMarketplace.js
@@ -138,7 +138,7 @@ function genPackDetails() {
     if (pack.contentItems) {
       var FixedContentItems = {};
       for (var [key, value] of Object.entries(pack.contentItems)) {
-        fixedKey = contentItemTransformer[key];
+        const fixedKey = contentItemTransformer[key];
         for (const listItem of value) {
           listItem.description = listItem.description
             ? jsStringEscape(listItem.description)

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -36,7 +36,7 @@
   --ifm-line-height-base: 1.5;
   --ifm-leading-desktop: 1.5;
   --ifm-list-margin: var(--ifm-leading);
-  --ifm-color-secondary: #9292c8;
+  --ifm-color-secondary: #768ba1;
   font-family: "Demisto", Fallback, sans-serif;
   /* Tables */
   --ifm-table-stripe-background: var(--ifm-background-color);
@@ -105,6 +105,14 @@ blockquote {
 .alert--success svg {
   fill: #fff;
   stroke: #fff;
+}
+
+.alert--secondary {
+  color: white;
+}
+
+.alert--secondary a {
+  color: white;
 }
 
 /* Hero overrides */

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -43,17 +43,14 @@
   --ifm-table-border-width: 0px;
 }
 
-.integrationImageContainer {
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  height: 27px;
-  width: 64px;
-  border: 1px solid #eaebeb;
-  margin-right: 8px;
-  margin-bottom: 8px;
-  background-color: #f4f5f5;
-  border-radius: 2px;
+.markdown table tr {
+  border-bottom: 1px solid var(--ifm-color-secondary);
+}
+
+.markdown table tr::after {
+  content: "";
+  display: block;
+  min-width: 268px;
 }
 
 /* Dark mode overrides */
@@ -462,6 +459,19 @@ html[data-theme="dark"] .header-github-link:before {
   margin-bottom: 2rem;
   height: 100vh;
   overflow: auto;
+}
+
+.integrationImageContainer {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  height: 27px;
+  width: 64px;
+  border: 1px solid #eaebeb;
+  margin-right: 8px;
+  margin-bottom: 8px;
+  background-color: #f4f5f5;
+  border-radius: 2px;
 }
 
 /* The main container element */

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -37,6 +37,12 @@
   --ifm-leading-desktop: 1.5;
   --ifm-list-margin: var(--ifm-leading);
   --ifm-color-secondary: #768ba1;
+  --ifm-color-secondary-dark: #667d95;
+  --ifm-color-secondary-darker: #61768d;
+  --ifm-color-secondary-darkest: #4f6174;
+  --ifm-color-secondary-light: #8799ac;
+  --ifm-color-secondary-lighter: #8fa0b2;
+  --ifm-color-secondary-lightest: #a8b5c3;
   font-family: "Demisto", Fallback, sans-serif;
   /* Tables */
   --ifm-table-stripe-background: var(--ifm-background-color);

--- a/src/theme/MarketplaceSidebar/index.js
+++ b/src/theme/MarketplaceSidebar/index.js
@@ -247,9 +247,6 @@ function SelectOne({
         color: "var(--ifm-font-color-base)",
       };
     },
-    singleValue: (styles) => {
-      color: "var(--ifm-font-color-base)";
-    },
   };
 
   if (async) {


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Status
Ready

## Related Issues
fixes: link to the issue

## Description
Small change to address color/display issues with `alert--secondary` component. The new color was taken from the in-product XSOAR marketplace and can also be seen when viewing pack details pages (table border, version, et al.)

## Screenshots
Paste here any images that will help the reviewer
