### PR TITLE
Code Conventions - add note about http call retries in the client section

### DIFF
--- a/docs/integrations/code-conventions.md
+++ b/docs/integrations/code-conventions.md
@@ -206,6 +206,10 @@ client = Client(
 )
 ```
 
+### HTTP Call Retries
+We do not allow using `sleep` in the code as it might lead to performance issues.
+Instead, you can utilize the retry mechanism implemented in the **BaseClient** by using the `retries` and `backoff_factor` arguments of the `_http_request` function.
+
 ## Command Functions
 These are the best practices for defining the command functions.
 - Each integration command should have a corresponding `_command` function.


### PR DESCRIPTION
## Status
Ready

## Description
refer to use the retry mechanism instead of sleep in the code conventions doc