### PR TITLE
Change daily trigger time

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -124,7 +124,8 @@ workflows:
   daily:
     triggers:
       - schedule:
-          cron: "0 5 * * *"
+          # should trigger every day at 1:00 & 13:00 UTC (4 hours after each upload-flow run)
+          cron: "0 1,13 * * *"
           filters:
             branches:
               only:


### PR DESCRIPTION
## Status
Ready

## Related Issues
https://github.com/demisto/etc/issues/32263

## Description
As part of https://github.com/demisto/etc/issues/32263 we will send updates on new packs to a slack channel, the new packs are calculated from the index. To avoid cases where the bucket is updated but MP section on xsoar.pan.dev is not, we've changed the deploy times of content-docs to be 4 hours after each upload (i.e. 1:00 & 13:00 UTC).

## Screenshots
Paste here any images that will help the reviewer
