### PR TITLE
Add GTM plugin

### DIFF
--- a/docusaurus-plugin-gtm/index.js
+++ b/docusaurus-plugin-gtm/index.js
@@ -1,0 +1,28 @@
+module.exports = function (context, options) {
+  const isProd = process.env.NODE_ENV === "production";
+  return {
+    name: "docusaurus-plugin-gtm",
+    injectHtmlTags() {
+      if (!isProd) {
+        return {};
+      }
+      return {
+        headTags: [
+          `<!-- Google Tag Manager -->
+<script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+})(window,document,'script','dataLayer','${options.gtm}');</script>
+<!-- End Google Tag Manager -->`,
+        ],
+        postBodyTags: [
+          `<!-- Google Tag Manager (noscript) -->
+<noscript><iframe src="https://www.googletagmanager.com/ns.html?id=${options.gtm}"
+height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+<!-- End Google Tag Manager (noscript) -->`,
+        ],
+      };
+    },
+  };
+};

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -231,6 +231,14 @@ module.exports = {
       rel: "stylesheet"
     },
   ],
+  plugins: [
+    [
+      require.resolve("./docusaurus-plugin-gtm/index.js"),
+      {
+        gtm: "GTM-KWZSPLM", //GTM-XXXXXX
+      },
+    ]
+  ],
   onBrokenLinks: "warn",
   onBrokenMarkdownLinks: "warn",
   onDuplicateRoutes: "warn"


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Status
In Progress

## Related Issues
fixes: link to the issue

## Description
Introduces custom `docusaurus-plugin-gtm` plugin that includes Google  Tag Manager (Google Analytics and HotJar). Plugin enables tags to function on Firebase, since we will no longer be relying on Netlify to inject these tags.

## Screenshots
Paste here any images that will help the reviewer
