### PR TITLE
replaced resource_class from large to xlarge

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ jobs:
   build:
     machine:
       image: ubuntu-2004:202101-01
-      resource_class: large
+      resource_class: xlarge
 
     parameters:
       slack_notify:


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Status
Ready.

## Related Issues
fixes: the last build failures.

## Description
this will fix the problem with exit status 137 (probably out of memory).