### PR TITLE
Add DT example

### DIFF
--- a/docs/playbooks/playbooks-extend_context.md
+++ b/docs/playbooks/playbooks-extend_context.md
@@ -44,3 +44,14 @@ When querying QRadar for offenses based on certain criteria, by default the syst
 
 2. Identify the fields that you want to add and run your command. For example, to retrieve the number of devices affected by a given offense as well as the domain in which those devices reside, run the following command:
    `!qradar-offenses extend-context=device-count=device_count::domain-id=domain_id`
+
+### DT Syntax to Get Select Keys from List of Dictionaries
+
+[DT syntax](https://xsoar.pan.dev/docs/integrations/dt) is supported within the `extend-context` value. You can use DT to get select keys of interest from a command that returns a list of dictionaries containing many keys. For example, the automation `findIndicators` returns a long list of indicator properties, and you may only be interested in saving the `value` and the `indicator_type` to minimize the size of context data.
+
+1. Run the command `!findIndicators size=2 query="type:IP" raw-response=true`. You will see a list of two dictionaries containing 20+ items.
+2. Use the following DT value for `extend-context` to save only `value` and `indicator_type` into a context key called `FoundIndicators`:
+
+   ```
+   !findIndicators size=2 query="type:IP" extend-context=`FoundIndicators=.={"value": val.value, "indicator_type": val.indicator_type}`
+   ```


### PR DESCRIPTION
Added DT `findIndicators` example at bottom of page

<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Status
Ready

## Related Issues
N/A

## Description
It is not obvious that you can use DT syntax inside the `extend-context` value. Adding an example with a common use case for using DT will help users.

## Screenshots
Screenshots of command and output:

![Screen Shot 2022-03-04 at 7 36 15 PM](https://user-images.githubusercontent.com/91506078/156864575-e605923d-f6f7-40be-b346-5d94514bf94d.png)

![Screen Shot 2022-03-04 at 7 36 22 PM](https://user-images.githubusercontent.com/91506078/156864576-90a983f5-da37-492b-b5a3-bb61d028bda0.png)

