### PR TITLE
fix the link

### DIFF
--- a/templates/details.hbs
+++ b/templates/details.hbs
@@ -27,7 +27,7 @@ return (
     </div>
 
     <main className={clsx("container", "contentPackAlign" )}>
-        <ContentPackTabs defaultValue="details" premium="{{premium}}" downloadUrl="https://marketplace-dist.storage.googleapis.com/content/packs/{{id}}/{{id}}_with_dependencies.zip"
+        <ContentPackTabs defaultValue="details" premium="{{premium}}" downloadUrl="https://marketplace-dist.storage.googleapis.com/content/packs/{{name}}/{{name}}_with_dependencies.zip"
         values={[ { label: "Details" , value: "details" }, { label: "Content" , value: "content" }, { label: "Dependencies" , value: "dependencies" }, { label: "Version History" , value: "versions" }]}>
             <TabItem value="details">
                 <div className="row">
@@ -233,7 +233,7 @@ return (
                                 <article dangerouslySetInnerHTML=\{{ __html:
                                     converter.makeHtml("{{{this.releaseNotes}}}"), }}></article>
                                 {{#unless ../premium}}
-                                <a className="button button--outline button--primary button--md" href="https://storage.googleapis.com/marketplace-dist/content/packs/{{../id}}/{{this.version}}/{{../id}}.zip" target="_blank" title="Warning: Downloading this pack without its required dependencies may result in failed installation.">Download</a>
+                                <a className="button button--outline button--primary button--md" href="https://storage.googleapis.com/marketplace-dist/content/packs/{{../name}}/{{this.version}}/{{../name}}.zip" target="_blank" title="Warning: Downloading this pack without its required dependencies may result in failed installation.">Download</a>
                                 {{/unless}}
                             </Collapsible>
                         </div>


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Status
Ready

## Related Issues
fixes: [link to the issue](https://github.com/demisto/etc/issues/47848)

## Description
Fix the issue when `content-docs Download Packs Leads to Wrong Link When Trying To Download Packs With Hyphens.`

## VIDEO
https://user-images.githubusercontent.com/71635916/162615487-4f92fd39-76a4-41e9-a8f0-26b17b35724a.mov


