### PR TITLE
Add support for wizard on marketplace page

### DIFF
--- a/genMarketplace.js
+++ b/genMarketplace.js
@@ -26,6 +26,7 @@ const contentItemTransformer = {
   classifier: "Classifiers",
   widget: "Widgets",
   dashboard: "Dashboards",
+  wizard: "Wizards",
 };
 
 const removeDir = function (path) {
@@ -307,7 +308,7 @@ function genPackDetails() {
           let fixedKey = ""
           var promises = []
           for (var [key, value] of Object.entries(pack.contentItems)) {
-            fixedKey = contentItemTransformer[key];
+            fixedKey = contentItemTransformer[key] || key;
             for (var listItem of value) {
               listItem.description = listItem.description
                 ? jsStringEscape(listItem.description)

--- a/genMarketplace.js
+++ b/genMarketplace.js
@@ -308,7 +308,7 @@ function genPackDetails() {
           let fixedKey = ""
           var promises = []
           for (var [key, value] of Object.entries(pack.contentItems)) {
-            fixedKey = contentItemTransformer[key] || key;
+            fixedKey = contentItemTransformer[key] || (key.charAt(0).toUpperCase() + key.slice(1));
             for (var listItem of value) {
               listItem.description = listItem.description
                 ? jsStringEscape(listItem.description)


### PR DESCRIPTION
## Status
Ready

## Related Issues
fixes: https://jira-hq.paloaltonetworks.local/browse/CIAC-3557

## Description
Add Wizard to supported content items, and use the provided content name when mapping is missing.