### PR TITLE
use details instead of name in indicator type

### DIFF
--- a/templates/details.hbs
+++ b/templates/details.hbs
@@ -144,10 +144,14 @@ return (
                                     <tbody>
                                         <tr className="infoTableRow">
                                             <td className="contentTableColName">
-                                                {{#if this.docLink}}
-                                                    <a href="{{this.docLink}}"> {{this.name}} </a>
+                                                {{#if this.name}}
+                                                    {{#if this.docLink}}
+                                                        <a href="{{this.docLink}}"> {{this.name}} </a>
+                                                    {{else}}
+                                                        <p>{{this.name}}</p>
+                                                    {{/if}}
                                                 {{else}}
-                                                    <p>{{this.name}}</p>
+                                                    <p>{{this.details}}</p>
                                                 {{/if}}
                                             </td>
                                             <td className="contentTableColDesc">


### PR DESCRIPTION
## Status
Ready/In Progress/In Hold (Reason for hold)

## Related Issues
fixes: https://jira-hq.paloaltonetworks.local/browse/CIAC-4235

## Description
There is no name in the indicator type json content. so we will use the `details` key as the name of the indicator type instead of the `name` key like in all other entities

## Screenshots
An example how the json of an indicator type looks like
![Screen Shot 2022-09-29 at 16 17 46](https://user-images.githubusercontent.com/78307768/193041982-bb971595-fa29-48be-8222-02b3a89ee549.png)
