### PR TITLE
fix broken links + formatting

### DIFF
--- a/docs/concepts/dev-setup.md
+++ b/docs/concepts/dev-setup.md
@@ -3,9 +3,9 @@ id: dev-setup
 title: Development Setup
 ---
 
-> <i>Important Note:</i>  
+:::info Important Note
 This article is focused on setting up a development environment to create and contribute supported new content. If you are not planning to contribute or your contribution will be only community supported, the content in this article is not required. For more details, refer to the [Getting Started Guide](../concepts/getting-started-guide#using-the-right-tools).
-
+:::
 
 **For details, the [Setup Tutorial](../tutorials/tut-setup-dev) summarizes the end-to-end steps that are required.**
 

--- a/docs/contributing/checklist.md
+++ b/docs/contributing/checklist.md
@@ -13,7 +13,7 @@ Happy contributing!
 
 No matter what you include in your content pack, the pack must include the following:
 
-- Pack Metadata file (i.e. `Packs/YourPackName/pack_metadata.json`) : the information about your content pack. It should be compiled with all the required information, as explained [here](../integrations/packs-format).
+- Pack Metadata file (i.e. `Packs/YourPackName/pack_metadata.json`) : the information about your content pack. It should be compiled with all the required information, as explained [here](../packs/packs-format).
 - Pack README (i.e. `Packs/YourPackName/README.md`): the readme of the pack file. More information [here](../documentation/pack-docs).
 - Release Notes (i.e. `Packs/YourPackName/ReleaseNotes/1_0_1.md`): these are required only if you are updating an existing Content pack, not for the first. More information [here](../documentation/release-notes).
 

--- a/docs/contributing/contributing.md
+++ b/docs/contributing/contributing.md
@@ -57,7 +57,7 @@ Please read the following guidelines carefully: following them will maximize the
     * Understand the [YAML file](../integrations/yaml-file) structure and the [Parameter Types](../integrations/parameter-types).
     * Make sure your integration follows our [Logo Guidelines](../integrations/integration-logo).
     * Read and follow [Python code conventions](../integrations/code-conventions) (recommended) or [Powershell code conventions](../integrations/powershell-code) (advanced users only).
-    * If your integration generates Incidents, follow the [Fetch Incidents](../fetching-incidents) guidelines.
+    * If your integration generates Incidents, follow the [Fetch Incidents](../integrations/fetching-incidents) guidelines.
     * Make sure your commands make proper use of the [Context](../integrations/context-and-outputs), including [Context Standards](../integrations/context-standards-about) and [DBotScore](../integrations/dbot).
     * Make sure to create unit tests as documented [here](../integrations/unit-testing) and that the various linters we support pass as detailed [here](../integrations/linting).
     * Document your integration and automation by generating the [README File](../documentation/readme_file).

--- a/docs/tutorials/tut-design.md
+++ b/docs/tutorials/tut-design.md
@@ -135,7 +135,7 @@ Integrations enable communications with third party APIs: in order to get them a
 
 Start your integration design by knowing the answers to the following questions:
  - What Product/API are you integrating with?
- - Which product [category](../integrations/packs-format#pack_metadatajson) does it belong to?
+ - Which product [category](../packs/packs-format#pack_metadatajson) does it belong to?
  - What version(s) of the product you are going to support?
  - Does it support on-prem deployment or SaaS only?
  - How does the authentication work?
@@ -228,7 +228,7 @@ Commands should be as atomic as possible (i.e. each command should ideally run a
 Make sure that commands run quickly and are non-blocking: a command should never take more than 2-3 seconds to run and return the information, or it would have significant performance impacts in XSOAR. **Avoid sleep() at all costs in your code**.
 
 If you have commands that need to run for longer periods of time, we recommend two approaches:
-- Make the commands asynchronous and implement a [Generic Polling](..//playbooks/generic-polling) mechanism. For example, if you need to run a search across your Endpoints, instead of having a single command that waits until the search is completed, you should implement three separate commands:
+- Make the commands asynchronous and implement a [Generic Polling](../playbooks/generic-polling) mechanism. For example, if you need to run a search across your Endpoints, instead of having a single command that waits until the search is completed, you should implement three separate commands:
   - A command that triggers the search and returns immediately a job id as output (i.e. `!helloworld-start-scan`).
   - A command that checks the status of the job taking the job id as input (i.e. `!helloworld-scan-status`).
   - A command that retrieves the results of a job when it's complete, taking the job id as input (i.e. `helloworld-scan-results`).

--- a/docs/welcome.md
+++ b/docs/welcome.md
@@ -14,7 +14,7 @@ Cortex XSOAR's security orchestration and automation enables standardized, autom
 
 The Cortex XSOAR Developer Hub is organized in different sections to guide you through the process of creating a successful Cortex XSOAR contribution. Start with the [Getting Started](concepts/getting-started-guide) section to understand the Cortex XSOAR concepts, the Contribution process, and to set up a development environment.
 
-On the left sidebar you'll find documentation for all the different things you can build: start with [Content Packs](integrations/packs-format) that represent the backbone of every contribution then, depending on what you want to create, explore the other sections accordingly: **Integrations & Scripts**, **Playbooks**, **Incidents, Fields & Layouts**.
+On the left sidebar you'll find documentation for all the different things you can build: start with [Content Packs](packs/packs-format) that represent the backbone of every contribution then, depending on what you want to create, explore the other sections accordingly: **Integrations & Scripts**, **Playbooks**, **Incidents, Fields & Layouts**.
 
 Finally, the **Tutorials** section includes longer end-to-end articles that guide you through a specific process (i.e. design).
 


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Status
Ready

## Related Issues
fixes: link to the issue

## Description
Small fixes to broken links that I noticed.

Also fix formatting for [dev-setup](https://xsoar.pan.dev/docs/concepts/dev-setup) note. Currently markdown wasn't displayed properly:

<img width="823" alt="image" src="https://user-images.githubusercontent.com/1395797/193398773-f48bb308-92f0-4344-857b-9692ee141bfa.png">


## Screenshots
Paste here any images that will help the reviewer
