### PR TITLE
Fixed an issue with Supported Versions for XSIAM products

### DIFF
--- a/content-repo/gendocs.py
+++ b/content-repo/gendocs.py
@@ -171,8 +171,12 @@ def get_deprecated_data(yml_data: dict, desc: str, readme_file: str):
 
 def get_fromversion_data(yml_data: dict):
     from_version = yml_data.get('fromversion', '')
+    marketplaces = yml_data.get('marketplaces', [])
     if from_version and not from_version.startswith(('4', '5.0')):
-        return f':::info Supported versions\nSupported Cortex XSOAR versions: {from_version} and later.\n:::\n\n'
+        if 'xsoar' in marketplaces:
+            return f':::info Supported versions\nSupported Cortex XSOAR versions: {from_version} and later.\n:::\n\n'
+        elif 'marketplacev2' in marketplaces:
+            return f':::info Supported versions\nSupported Cortex XSIAM versions: {from_version} and later.\n:::\n\n'
     return ''
 
 

--- a/content-repo/gendocs.py
+++ b/content-repo/gendocs.py
@@ -173,7 +173,10 @@ def get_fromversion_data(yml_data: dict):
     from_version = yml_data.get('fromversion', '')
     marketplaces = yml_data.get('marketplaces', [])
     if from_version and not from_version.startswith(('4', '5.0')):
-        if 'xsoar' in marketplaces:
+        if 'xsoar' in marketplaces and 'marketplacev2' in marketplaces:
+            return f':::info Supported versions\nSupported Cortex XSOAR versions: {from_version} and later.\n:::\n\n' \
+                   f':::info Supported versions\nSupported Cortex XSIAM versions: {from_version} and later.\n:::\n\n'
+        elif 'xsoar' in marketplaces:
             return f':::info Supported versions\nSupported Cortex XSOAR versions: {from_version} and later.\n:::\n\n'
         elif 'marketplacev2' in marketplaces:
             return f':::info Supported versions\nSupported Cortex XSIAM versions: {from_version} and later.\n:::\n\n'

--- a/content-repo/gendocs.py
+++ b/content-repo/gendocs.py
@@ -173,13 +173,14 @@ def get_fromversion_data(yml_data: dict):
     from_version = yml_data.get('fromversion', '')
     marketplaces = yml_data.get('marketplaces', [])
     if from_version and not from_version.startswith(('4', '5.0')):
-        if 'xsoar' in marketplaces and 'marketplacev2' in marketplaces:
-            return f':::info Supported versions\nSupported Cortex XSOAR versions: {from_version} and later.\n:::\n\n' \
-                   f':::info Supported versions\nSupported Cortex XSIAM versions: {from_version} and later.\n:::\n\n'
-        elif 'xsoar' in marketplaces:
+        if 'marketplacev2' in marketplaces:
+            if 'xsoar' in marketplaces:
+                return f':::info Supported versions\nSupported Cortex XSOAR versions: {from_version} and later.\n:::\n\n' \
+                       f':::info Supported versions\nSupported Cortex XSIAM versions: {from_version} and later.\n:::\n\n'
+            else:
+                return f':::info Supported versions\nSupported Cortex XSIAM versions: {from_version} and later.\n:::\n\n'
+        else:
             return f':::info Supported versions\nSupported Cortex XSOAR versions: {from_version} and later.\n:::\n\n'
-        elif 'marketplacev2' in marketplaces:
-            return f':::info Supported versions\nSupported Cortex XSIAM versions: {from_version} and later.\n:::\n\n'
     return ''
 
 

--- a/content-repo/gendocs_test.py
+++ b/content-repo/gendocs_test.py
@@ -131,6 +131,7 @@ def test_findfiles():
         (
                 '6-0-0-integration',
                 {
+                    'marketplaces': ['xsoar'],
                     'fromversion': '6.0.0',
                     'description': 'Manage Alibaba Cloud Elastic Compute Instances'
                 },

--- a/content-repo/gendocs_test.py
+++ b/content-repo/gendocs_test.py
@@ -318,9 +318,18 @@ def test_get_deprecated_data():
     assert "Add information" not in res
 
 
-@pytest.mark.parametrize("test_input, expected", [({'fromversion': '5.5.0'},
+@pytest.mark.parametrize("test_input, expected", [({'fromversion': '5.5.0'}, ''),
+                                                  ({'fromversion': '5.5.0', 'marketplaces': ['xsoar', 'marketplacev2']},
+                                                   ':::info Supported versions\nSupported '
+                                                   'Cortex XSOAR versions: 5.5.0 and later.\n:::\n\n'
+                                                   ':::info Supported versions\nSupported '
+                                                   'Cortex XSIAM versions: 5.5.0 and later.\n:::\n\n'),
+                                                  ({'fromversion': '5.5.0', 'marketplaces': ['xsoar']},
                                                    ':::info Supported versions\nSupported '
                                                    'Cortex XSOAR versions: 5.5.0 and later.\n:::\n\n'),
+                                                  ({'fromversion': '5.5.0', 'marketplaces': ['marketplacev2']},
+                                                   ':::info Supported versions\nSupported '
+                                                   'Cortex XSIAM versions: 5.5.0 and later.\n:::\n\n'),
                                                   ({'fromversion': '5.0.0'}, ''),
                                                   ({}, ''),
                                                   ({'fromversion': '4.0.0'}, '')])

--- a/content-repo/gendocs_test.py
+++ b/content-repo/gendocs_test.py
@@ -131,7 +131,6 @@ def test_findfiles():
         (
                 '6-0-0-integration',
                 {
-                    'marketplaces': ['xsoar'],
                     'fromversion': '6.0.0',
                     'description': 'Manage Alibaba Cloud Elastic Compute Instances'
                 },
@@ -319,7 +318,9 @@ def test_get_deprecated_data():
     assert "Add information" not in res
 
 
-@pytest.mark.parametrize("test_input, expected", [({'fromversion': '5.5.0'}, ''),
+@pytest.mark.parametrize("test_input, expected", [({'fromversion': '5.5.0'},
+                                                   ':::info Supported versions\nSupported '
+                                                   'Cortex XSOAR versions: 5.5.0 and later.\n:::\n\n'),
                                                   ({'fromversion': '5.5.0', 'marketplaces': ['xsoar', 'marketplacev2']},
                                                    ':::info Supported versions\nSupported '
                                                    'Cortex XSOAR versions: 5.5.0 and later.\n:::\n\n'


### PR DESCRIPTION
## Status
Ready

## Related Issues
fixes: https://jira-hq.paloaltonetworks.local/browse/CIAC-4693

## Description
fixed an issue with the `supported from version` note in `XSIAM` products.

## Screenshots
A screenshot from production (before the fix). The integration is actually an XISAM (only) integration not XSOAR:
<img width="808" alt="Screen Shot 2022-11-28 at 12 45 47" src="https://user-images.githubusercontent.com/78307768/204259021-6a783529-0e2f-4692-aa0a-7d7dfb70e3e9.png">
After the fix a XSIAM (only) integration:
<img width="824" alt="Screen Shot 2022-11-28 at 12 48 50" src="https://user-images.githubusercontent.com/78307768/204259405-7e2388f3-7662-436c-91dc-b8692095caed.png">
After the fix a XSOAR (only) integration:
![Screen Shot 2022-11-28 at 15 06 55](https://user-images.githubusercontent.com/78307768/204285490-8fe433a6-09a5-4a01-b716-0480eb6fcb9f.png)
After the fix an integration which is in both marketplaces:
<img width="832" alt="Screen Shot 2022-11-28 at 12 49 04" src="https://user-images.githubusercontent.com/78307768/204259597-ee856824-8381-4c03-9784-bbe473356fad.png">
