### PR TITLE
remove contentItemsDocsLinks from git ignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,7 +11,6 @@
 # generated files
 .docusaurus
 .cache-loader
-content-repo/contentItemsDocsLinks.json
 
 # production
 /build


### PR DESCRIPTION

## Status
Ready

## Related Issues
fixes: link to the issue

## Description
Expand the contentItemsDocsLinks file to be able to access it from the cortex-marketplace new repo

## Screenshots
Paste here any images that will help the reviewer
