### PR TITLE
upload content items links file to the bucket

### DIFF
--- a/content-repo/gendocs.py
+++ b/content-repo/gendocs.py
@@ -108,7 +108,7 @@ def update_contributors_file(service_account_file, list_links):
     """
         Updates the contentItemsDocsLinks json file.
         Args:
-            service_account_file (Object): Service account file which uses to connect to the bucket.
+            service_account_file (Object): A Service Account file which used to connect to the bucket.
             list_links (Dict[str: str]): Dict of {content item name: path in xsoar.pan.dev}.
                 for example: {"Aha": "https://xsoar.pan.dev/docs/reference/integrations/aha"}
     """

--- a/content-repo/gendocs.py
+++ b/content-repo/gendocs.py
@@ -95,7 +95,7 @@ SERVICE_ACCOUNT = os.getenv('GCP_SERVICE_ACCOUNT')
 
 def create_service_account_file():
     """
-    Create a service account json file from the circle variable.
+        Create a service account json file from the circle variable.
     """
     service_account_file = tempfile.NamedTemporaryFile(delete=False, mode='w', suffix='.json')
     service_account_file.write(SERVICE_ACCOUNT)
@@ -106,7 +106,11 @@ def create_service_account_file():
 
 def update_contributors_file(service_account_file, list_links):
     """
-    Updates the service account json file.
+        Updates the contentItemsDocsLinks json file.
+        Args:
+            service_account_file (Object): Service account file which uses to connect to the bucket.
+            list_links (Dict[str: str]): Dict of {content item name: path in xsoar.pan.dev}.
+                for example: {"Aha": "https://xsoar.pan.dev/docs/reference/integrations/aha"}
     """
     storage_client = storage.Client.from_service_account_json(service_account_file)
     bucket = storage_client.bucket('xsoar-ci-artifacts')

--- a/content-repo/gendocs.py
+++ b/content-repo/gendocs.py
@@ -930,7 +930,7 @@ See: https://github.com/demisto/content-docs/#generating-reference-docs''',
         insert_approved_tags_and_usecases()
 
     print("Writing json links into contentItemsDocsLinks.json")
-    update_contributors_file(json.dumps(DOCS_LINKS_JSON), create_service_account_file())
+    update_contributors_file(create_service_account_file().name, json.dumps(DOCS_LINKS_JSON, indent=4))
 
 
 if __name__ == "__main__":

--- a/content-repo/gendocs.py
+++ b/content-repo/gendocs.py
@@ -930,7 +930,7 @@ See: https://github.com/demisto/content-docs/#generating-reference-docs''',
         insert_approved_tags_and_usecases()
 
     print("Writing json links into contentItemsDocsLinks.json")
-    update_contributors_file(DOCS_LINKS_JSON, create_service_account_file())
+    update_contributors_file(json.dumps(DOCS_LINKS_JSON), create_service_account_file())
 
 
 if __name__ == "__main__":

--- a/content-repo/gendocs.py
+++ b/content-repo/gendocs.py
@@ -98,7 +98,7 @@ def create_service_account_file():
     Create a service account json file from the circle variable.
     """
     service_account_file = tempfile.NamedTemporaryFile(delete=False, mode='w', suffix='.json')
-    json.dump(json.loads(SERVICE_ACCOUNT), service_account_file)
+    service_account_file.write(SERVICE_ACCOUNT)
     service_account_file.flush()
 
     return service_account_file


### PR DESCRIPTION

## Status
Ready

## Related Issues
fixes: https://jira-hq.paloaltonetworks.local/browse/CIAC-4779

## Description
Since we moved the marketplace to a new repo the contentDocsLinks file (which is in use in the marketplace repo) we upload the file to the bucket.

## Screenshots
Paste here any images that will help the reviewer
