### PR TITLE
show arrows in dark mode

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -71,8 +71,6 @@ html[data-theme="dark"] {
 
   --ifm-hover-overlay: rgba(255, 255, 255, 0.05);
 
-  --ifm-menu-link-sublist-icon: url('data:image/svg+xml;utf8,<svg alt="Arrow" xmlns="http://www.w3.org/2000/svg" width="16px" height="16px" viewBox="0 0 24 24"><path fill="rgba(255,255,255,0.6)" d="M7.41 15.41L12 10.83l4.59 4.58L18 14l-6-6-6 6z"></path></svg>');
-
   --ifm-color-content-secondary: rgba(255, 255, 255, 1);
 
   --ifm-navbar-background-color: #4d494a;


### PR DESCRIPTION

## Status
Ready

## Related Issues
fixes: https://jira-hq.paloaltonetworks.local/browse/CIAC-2190

## Description
Removed the URL in the CSS to show the arrows in dark mode

## Screenshots
Before the fix:
![Screen Shot 2022-12-25 at 13 11 46](https://user-images.githubusercontent.com/78307768/209465756-00d8509d-10fb-4b03-8a21-4d53d79ea025.png)

After the fix:
![Screen Shot 2022-12-25 at 13 11 34](https://user-images.githubusercontent.com/78307768/209465771-adec8006-53a4-4ade-8d82-ded8b709e47d.png)
