### PR TITLE
Add default value of an empty dict to nested `.get()` calls

### DIFF
--- a/docs/integrations/code-conventions.md
+++ b/docs/integrations/code-conventions.md
@@ -187,8 +187,8 @@ client = Client(
 
 #### Example - client instance using Basic Authentication
 ```python
-username = demisto.params().get('credentials').get('identifier')
-password = demisto.params().get('credentials').get('password')
+username = demisto.params().get('credentials', {}).get('identifier')
+password = demisto.params().get('credentials', {}).get('password')
 
 # get the service API url
 base_url = urljoin(demisto.params()['url'], '/api/v1')
@@ -578,8 +578,8 @@ When working on integrations that require user credentials (such as username/pas
 - **And in the code:**
 ```python
 params = demisto.params()
-username = params.get('credentials').get('identifier')
-password = params.get('credentials').get('password')
+username = params.get('credentials', {}).get('identifier')
+password = params.get('credentials', {}).get('password')
 ```
 - **In demistomock.py:**
 ```python


### PR DESCRIPTION
## Status
Ready

## Description
Fix unsafe code on the docs, which uses nested `.get()` without adding a default value of an empty dict (can result in a `None.get()` call, which leads to an exception).

Relevant docs section: https://xsoar.pan.dev/docs/integrations/code-conventions#credentials

## Screenshots
<img width="810" alt="Screen Shot 2023-01-05 at 16 50 26" src="https://user-images.githubusercontent.com/8832013/210808378-8143b9b8-e528-44b6-b486-0f238b6f652c.png">
