### PR TITLE
fix slack notifier

### DIFF
--- a/build_utils/slack_notifier.py
+++ b/build_utils/slack_notifier.py
@@ -67,7 +67,6 @@ def create_slack_notifier(slack_token: str, build_url: str, ci_token: str, build
         slack_client = WebClient(token=slack_token)
         slack_client.chat_postMessage(
             channel=SLACK_CHANNEL,
-            as_user=False,
             username="Content-Docs CircleCI",
             attachments=[{
                 'color': color,


### PR DESCRIPTION

## Status
Ready

## Related Issues
fixes: link to the issue

## Description
Removed the deprecated `as_user=False` arg from the slack notifier.

## Screenshots
Paste here any images that will help the reviewer
