### PR TITLE
:ns 247, 251: straightened out key definition

### DIFF
--- a/docs/tutorials/tut-integration-ui.md
+++ b/docs/tutorials/tut-integration-ui.md
@@ -244,11 +244,11 @@ def translate_command(client: Client, text: str) -> CommandResults:
         raise DemistoException('Translation failed: the response from server did not include `translated`.',
                                res=response)
 
-    outputs = {Phrase: {'Original': text,
+    outputs = {'Phrase': {'Original': text,
                             'Translation': translated}}
 
     return CommandResults(outputs_prefix='YodaSpeak',
-                          outputs_key_field=’Phrase.Original',
+                          outputs_key_field='Phrase.Original',
                           outputs=outputs,
                           raw_response=response,
                           readable_output=tableToMarkdown(name='Yoda Says...', t=outputs))


### PR DESCRIPTION
Used single quotes around Phrase on line 247 and replaced tick with single quote before Phrase on line 251.

<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Status
Ready/In Progress/In Hold (Reason for hold)

## Related Issues
fixes: link to the issue

## Description
A few sentences describing the overall goals of the pull request's commits.

## Screenshots
Paste here any images that will help the reviewer
