### PR TITLE
Update Scheduled Command doc - remove raise_error_if_not_supported

### DIFF
--- a/docs/integrations/scheduled-commands.md
+++ b/docs/integrations/scheduled-commands.md
@@ -144,7 +144,6 @@ In the example below, if the `status` is not `complete` then a result with `sche
 
 ```python
 def run_polling_command(args: dict, cmd: str, search_function: Callable, results_function: Callable):
-    ScheduledCommand.raise_error_if_not_supported()
     interval_in_secs = int(args.get('interval_in_seconds', 60))
     if 'af_cookie' not in args:
         # create new search


### PR DESCRIPTION
## Status
Ready

## Description
raise_error_if_not_supported is no longer required, as all GA version of XSOAR support schedueld commands.