### PR TITLE
New explanation for adding images to the pack's readme file

### DIFF
--- a/docs/documentation/pack-docs.md
+++ b/docs/documentation/pack-docs.md
@@ -75,20 +75,20 @@ Note that "Cortex XSOAR Developer Docs" should link **directly to the readme of 
 
 ### Images
 Images can provide a great addition to the Pack `README.md` and can help users to get a quick understanding of the Pack. 
-To add an image to the readme pack, enter it under the binary_files directory in the relevant pack. (If there isn't one, create it).
+To add an image to the readme pack, enter it under the `readme_images` directory in the relevant pack. (If there isn't one, create it).
 
 Embed the image in the README.md using a Markdown Image Link, such as:
 ```
-![Playbook Image](binary_files/AutoFocusPolling.png)
+![Playbook Image](readme_images/AutoFocusPolling.png)
 ```
 Or if you want more control on the image (for example setting width dimension) you can use the HTML `<img>` tag, such as:
 ```
-<img width="500" src="binary_files/AutoFocusPolling.png" />
+<img width="500" src="readme_images/AutoFocusPolling.png" />
 ```
 
 **Note**:
 - Absolute image URLs are not supported for Pack `README`s.
-- The images must be under `binary_files` directory in the relevant pack.
+- The images must be under `readme_images` directory in the relevant pack.
 
 ### Videos
 It is possible to add an image placeholder which links to an external video. For example to add an external video hosted on YouTube use the following snippet template (replace `[YOUTUBE_VIDEO_ID]` with the YouTube video ID):

--- a/docs/documentation/pack-docs.md
+++ b/docs/documentation/pack-docs.md
@@ -74,7 +74,21 @@ Note that "Cortex XSOAR Developer Docs" should link **directly to the readme of 
 ![image](https://user-images.githubusercontent.com/43602124/88673366-31d59c80-d0f1-11ea-9319-b7d9f2fb8625.png)
 
 ### Images
-Images can provide a great addition to the Pack `README.md` and can help users to get a quick understanding of the Pack. Images can be included only as **absolute** urls. See the [following for instructions](../documentation/readme_file#absolute-image-urls). 
+Images can provide a great addition to the Pack `README.md` and can help users to get a quick understanding of the Pack. 
+To add an image to the readme pack, enter it under the binary_files directory in the relevant pack. (If there isn't one, create it).
+
+Embed the image in the README.md using a Markdown Image Link, such as:
+```
+![Playbook Image](binary_files/AutoFocusPolling.png)
+```
+Or if you want more control on the image (for example setting width dimension) you can use the HTML `<img>` tag, such as:
+```
+<img width="500" src="binary_files/AutoFocusPolling.png" />
+```
+
+**Note**:
+- Absolute image URLs are not supported for Pack `README`s.
+- The images must be under `binary_files` directory in the relevant pack.
 
 ### Videos
 It is possible to add an image placeholder which links to an external video. For example to add an external video hosted on YouTube use the following snippet template (replace `[YOUTUBE_VIDEO_ID]` with the YouTube video ID):

--- a/docs/documentation/readme_file.md
+++ b/docs/documentation/readme_file.md
@@ -70,7 +70,7 @@ When creating Markdown `README` documents for XSOAR entities (Playbooks, Integra
 
 Make sure to view the `README.md` file in GitHub's web interface and validate that the images display properly.
 
-**Note**: Relative image URLs are not supported for [Pack `README`s](https://xsoar.pan.dev/docs/documentation/pack-docs).
+**Note**: Relative image URLs are also supported for pack READMEs, See the [following for instructions](https://xsoar.pan.dev/docs/documentation/pack-docs#images).
 
 **Documentation with Relative URL examples:**
 * Google Calendar: https://github.com/demisto/content/blob/master/Packs/GoogleCalendar/Integrations/GoogleCalendar/README.md
@@ -95,6 +95,9 @@ Or if you want more control on the image (for example setting width dimension) y
 ```
 <img width="500" src="https://github.com/demisto/content/raw/2d6e082cfb181f823e5b1446ae71e10537591ea6/Packs/AutoFocus/doc_files/AutoFocusPolling.png" />
 ```
+
+**Note**: Absolute image URLs are not supported for [Pack READMEs](https://xsoar.pan.dev/docs/documentation/pack-docs#images).
+
 **Screenshot of `Download` button:**
 ![Github Download](/doc_imgs/integrations/github-download-button.png)
 


### PR DESCRIPTION

## Related Issues
fixes: https://jira-hq.paloaltonetworks.local/browse/CIAC-6017

## Description
Add to the `Pack Documentation` page a new explanation about adding images to the pack's readme file following a change that was decided that it is not possible to add absolute image paths but only relative paths to the `binary_files` directory under the relevant pack

## Screenshots
Paste here any images that will help the reviewer
