### PR TITLE
Update DBot Reliability Docs

### DIFF
--- a/docs/integrations/dbot.md
+++ b/docs/integrations/dbot.md
@@ -28,19 +28,30 @@ The DBot score must be at the root level of the context and contain **all** the 
 | Message | Optional message to show an API response. For example, `"Not found"`. | Optional |
 
 ## Reliability Level
-When merging indicators, the reliability of an intelligence-data source influences the reputation of an indicator and the values for
-indicator fields. Integration that outputs a DBotScore object, and hence defines each indicator's reliability, should allow the user to manually configure the default reliability for the created indicator DBotScore. This is done by adding a **Source Reliability** parameter to the integration which is later used when creating the object.
-**NOTE:** The values are case sensitive.
+When merging indicators, the reliability of an intelligence-data source impacts the reputation of an indicator and the values assigned to indicator fields.  
+Integration that outputs a DBotScore object, and hence defines each indicator's reliability, should allow the user to manually configure the default reliability for the generated indicator's DBotScore.  
 
+To achieve this, a **Source Reliability** (named `integration_reliability`) parameter has to be implemented in the YAML file.  
+This parameter is later used to determine the reliability level when creating the DBotScore object.
+
+### Example of Implementing a Reliability Parameter (in an integration's YAML file)
 ``` 
-  A+ - 3rd party enrichment  
-  A - Completely reliable 
-  B - Usually reliable  
-  C - Fairly reliable  
-  D - Not usually reliable  
-  E - Unreliable  
-  F - Reliability cannot be judged  
+- name: integration_reliability
+  display: Source Reliability
+  additionalinfo: Reliability of the source providing the intelligence data.
+  defaultvalue: C - Fairly reliable
+  options:
+  - A+ - 3rd party enrichment
+  - A - Completely reliable
+  - B - Usually reliable
+  - C - Fairly reliable
+  - D - Not usually reliable
+  - E - Unreliable
+  - F - Reliability cannot be judged
+  required: true
+  type: 15
  ```
+ **NOTE:** The values are case sensitive.
 
 ## Score Types
 Dbot uses an integer to represent the reputation of an indicator.


### PR DESCRIPTION
## Status
Ready

## Related Issues
relates: [link to the issue](https://jira-hq.paloaltonetworks.local/browse/CIAC-3678)

## Description
Update DBot docs to specify a standard name for the reliability field, and add an example YAML file.
Link to existing prod docs: https://xsoar.pan.dev/docs/integrations/dbot#reliability-level

## Screenshots
<img width="1025" alt="Screenshot 2023-05-22 at 17 27 26" src="https://github.com/demisto/content-docs/assets/8832013/5d3191fb-3816-42a2-b0e8-3b53116d59af">

