### PR TITLE
Fix typo from demsito to demisto

### DIFF
--- a/docs/concepts/demisto-sdk.md
+++ b/docs/concepts/demisto-sdk.md
@@ -307,7 +307,7 @@ You have a responsibility to identify and eliminate any secrets before they get 
 - Detect secrets in your files:
 
     ```buildoutcfg
-    demsito-sdk secrets
+    demisto-sdk secrets
     ```
 
    This detects secrets in all your changed files. Please note that this command can have some false positives. You can make the command less sensitive by adding the `-ie` flag.
@@ -442,7 +442,7 @@ local environment in order to continue with the contribution process.
 - Download a file to a given pack:
 
     ```buildoutcfg
-    demsito-sdk download -i "My Integration" -o Packs/myPack
+    demisto-sdk download -i "My Integration" -o Packs/myPack
     ```
 
    This downloads the entity named `My Integration` and places it in the appropriate directory within `myPack`.
@@ -451,7 +451,7 @@ local environment in order to continue with the contribution process.
 - Download several files to a given pack and overwrite any file which already exists:
 
     ```buildoutcfg
-    demsito-sdk download -i "My Integration" -i myScript -o Packs/myPack -f
+    demisto-sdk download -i "My Integration" -i myScript -o Packs/myPack -f
     ```
 
    This downloads both the `My Integration` and `myScript` entities to `myPack`. If any of the files already exist in the pack they are overwritten.


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Status
Ready

## Related PRs
https://github.com/demisto/content-docs/pull/1334

## Description
Fixed typo demsito => demisto.

## Screenshots
Paste here any images that will help the reviewer
