### PR TITLE
Added the first_fetch and max_fetch to fetch-incidents docs

### DIFF
--- a/docs/integrations/fetching-incidents.md
+++ b/docs/integrations/fetching-incidents.md
@@ -48,6 +48,8 @@ To set up the first run properly, use an ```if``` statement with a time that is 
 
 It is best practice to specify how far back in time to fetch incidents on the first run. This is a configurable parameter in the integration settings.
 
+Make sure that first_fetch param exist in the yml file.
+
 ## Query and Parameters
 
 Queries and parameters enable filtering events.  
@@ -71,7 +73,8 @@ The following example uses the **First Run** ```if``` statement and **query**.
 
 ### Fetch Limit 
 The *Fetch Limit* parameter sets the maximum number of incidents to get per fetch command. To maintain an optimal load on Cortex XSOAR we recommend setting a limit of 200 incidents per fetch.  
-**Note:** 
+**Note:**
+Make sure that the max_fetch parameter exist in the yml and has a default value.
 If you enter a larger number or leave *Fetch Limit* blank, the **Test** button will fail.
 
 ## Create an Incident

--- a/docs/integrations/fetching-incidents.md
+++ b/docs/integrations/fetching-incidents.md
@@ -48,7 +48,7 @@ To set up the first run properly, use an ```if``` statement with a time that is 
 
 It is best practice to specify how far back in time to fetch incidents on the first run. This is a configurable parameter in the integration settings.
 
-Make sure that first_fetch param exist in the yml file.
+Make sure that first_fetch parameter exist in the integration yml file.
 
 ## Query and Parameters
 
@@ -74,7 +74,7 @@ The following example uses the **First Run** ```if``` statement and **query**.
 ### Fetch Limit 
 The *Fetch Limit* parameter sets the maximum number of incidents to get per fetch command. To maintain an optimal load on Cortex XSOAR we recommend setting a limit of 200 incidents per fetch.  
 **Note:**
-Make sure that the max_fetch parameter exist in the yml and has a default value.
+Make sure that the max_fetch parameter exist in the integration yml file and it has a default value.
 If you enter a larger number or leave *Fetch Limit* blank, the **Test** button will fail.
 
 ## Create an Incident


### PR DESCRIPTION
In the SDK we have a validation that validates that the max_fetch and first_fetch params exist in the yml and the max_fetch has default value. It is necessary to add it to the fetch incident docs.

## Status
Ready

## Related Issues
fixes: [link to the issue](https://jira-hq.paloaltonetworks.local/browse/CIAC-7371)

