### PR TITLE
[Slack Notifier] - Build stage will send on nightly the status

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -85,10 +85,10 @@ jobs:
             - build
       - run:
           name: Notify Slack
-          when: on_fail
+          when: always
           command: |
             if [ "<<parameters.slack_notify>>" = "true" ]; then
-              pipenv run python ./build_utils/slack_notifier.py -s "$SLACK_TOKEN" -u "$CIRCLE_BUILD_URL" -b "$CIRCLE_BUILD_NUM" -c "$CIRCLECI_TOKEN"
+              pipenv run python ./build_utils/slack_notifier.py -s "$SLACK_TOKEN" -u "$CIRCLE_BUILD_URL" -b "$CIRCLE_BUILD_NUM" -c "$CIRCLECI_TOKEN" -sn "Build"
             fi
 
   deploy:
@@ -145,7 +145,7 @@ jobs:
           when: always
           command: |
             if [ "<<parameters.slack_notify>>" = "true" ]; then
-              pipenv run python ./build_utils/slack_notifier.py -s "$SLACK_TOKEN" -u "$CIRCLE_BUILD_URL" -b "$CIRCLE_BUILD_NUM" -c "$CIRCLECI_TOKEN"
+              pipenv run python ./build_utils/slack_notifier.py -s "$SLACK_TOKEN" -u "$CIRCLE_BUILD_URL" -b "$CIRCLE_BUILD_NUM" -c "$CIRCLECI_TOKEN" -sn "Deploy"
             fi
 
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,7 @@ jobs:
       slack_notify:
         description: Indicates whether to send a slack notification or not (on daily job we send notification)
         type: boolean
-        default: false
+        default: true
 
     steps:
       - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,7 @@ jobs:
       slack_notify:
         description: Indicates whether to send a slack notification or not (on daily job we send notification)
         type: boolean
-        default: true
+        default: false
 
     steps:
       - checkout
@@ -103,7 +103,7 @@ jobs:
       slack_notify:
         description: Indicates whether to send a slack notification or not (on daily job we send notification)
         type: boolean
-        default: true
+        default: false
     steps:
       - checkout
       - attach_workspace:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -103,7 +103,7 @@ jobs:
       slack_notify:
         description: Indicates whether to send a slack notification or not (on daily job we send notification)
         type: boolean
-        default: false
+        default: true
     steps:
       - checkout
       - attach_workspace:

--- a/build_utils/slack_notifier.py
+++ b/build_utils/slack_notifier.py
@@ -6,7 +6,7 @@ from circleci.api import Api as circle_api
 from slack_sdk import WebClient
 from slack_sdk.errors import SlackApiError
 
-SLACK_CHANNEL = 'U027A61KVUK'
+SLACK_CHANNEL = '#dmst-build'
 BUILD_STAGE = 'Build'
 DEPLOY_STAGE = 'Deploy'
 


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Status
Ready

## Related Issues
fixes:[ link to the issue](https://jira-hq.paloaltonetworks.local/browse/CIAC-6882)

## Description

Before this pr, the Build stage was sending message only on failure.
And the Deploy stage always.

Now, it will send on the Build stage also when there are failings on the "NPM Build content-repo docs" stage. 

## Screenshots
<img width="363" alt="image" src="https://github.com/demisto/content-docs/assets/89336697/a590dc3e-92c6-4121-9b84-4dded7745c53">

