### PR TITLE
Update content-management.md

### DIFF
--- a/content-repo/extra-docs/packs/content-management.md
+++ b/content-repo/extra-docs/packs/content-management.md
@@ -876,7 +876,7 @@ If you have custom Integrations, after the first upload by the CI/CD you may nee
     :::
     - Change the *dry_run* input to `false` and run the playbook again.
 
-3. (Optional) Add a **Server Configuration** only if you have custom Integrations.
+3. (Optional) Add a **Server Configuration** only if you have custom Integrations (Available from Cortex XSOAR 6.11.0).
    - In the Cortex XSOAR platform, go to **Settings** > **About** > **Troubleshooting**.
    - Click **Add Server Configuration**.
    - In the **Key** field, enter `allow.name.override.propagation`.


### PR DESCRIPTION
## Status
Ready

## Related Issues
fixes: [link to the issue](https://jira-hq.paloaltonetworks.local/browse/CIAC-5218)
fixes: [link to the issue](https://jira-hq.paloaltonetworks.local/browse/XSUP-23689)

## Description
The flag `allow.name.override.propagation` is only supported from version 6.11.0