### PR TITLE
Updated the Phishing Campaign documentation

### DIFF
--- a/content-repo/extra-docs/packs/Phishing-Campaign.md
+++ b/content-repo/extra-docs/packs/Phishing-Campaign.md
@@ -1,3 +1,4 @@
+
 ---
 id: phishing-campaign
 title: Phishing Campaign
@@ -17,7 +18,7 @@ As phishing campaigns are a number of phishing incidents that are similar to eac
 
 ![image](https://user-images.githubusercontent.com/43602124/124762458-97eeb480-df3b-11eb-9479-2214037befea.png)
 
-Included in this content pack is the **Detect & Manage Phishing Campaigns** playbook. Use this playbook in the [Phishing Investigation Generic V2 playbook](https://xsoar.pan.dev/docs/reference/playbooks/phishing-investigation---generic-v2), or use it in your custom phishing playbook. As part of the phishing incident, the playbook does the following: 
+Included in this content pack is the **Detect & Manage Phishing Campaigns** playbook. Use this playbook in the [Phishing - Generic v3](https://xsoar.pan.dev/docs/reference/playbooks/phishing---generic-v3), or use it in your custom phishing playbook. As part of the phishing incident, the playbook does the following: 
  - Finds and links related incidents to the same phishing attack (a phishing campaign).
  - Searches for an existing Phishing Campaign incident or creates a new incident for the linked Phishing incidents.
  - Links all detected phishing incidents to the Phishing Campaign incident that was found or that was previously created.
@@ -39,6 +40,12 @@ The **Phishing Campaign** content pack contains several content items.
 - **IsIncidentPartOfCampaign Automation**
  
   The **IsIncidentPartOfCampaign** automation takes the list of incidents detected as similar by the **FindEmailCampaign** automation, and checks whether one of them is already linked to a Phishing Campaign incident. If so, it outputs the ID of that incident so that all the similar phishing incidents can be linked to it. This automation finds whether there is an existing campaign incident or whether a new incident needs to be created.
+
+- **SetPhishingCampaignDetails Automation**
+The **SetPhishingCampaignDetails** automation updates the Phishing Campaign incident that was found, or was just created by the playbook, with new information outputted from the **FindEmailCampaign** script.
+Specifically, if the current phishing incident is not already in the context of the Phishing Campaign incident, it will add that incident along with its data. It will also update the similarities of all the Phishing incidents that are part of that Phishing Campaign incident, relative to the incident that was *created* last.
+
+**Note:** The last created incident is not necessarily the last incident that updated the Phishing Campaign. This is due to the nature of phishing campaigns, where multiple phishing incidents are typically processed at the same time. This behavior in managed through a lock mechanism which ensures that the incidents are processed synchronously (one by one). However, it cannot be guaranteed that the first ingested incident will be the first to acquire the lock and the first to be processed, since different incidents may take different amount of time to reach the Detect & Manage Phishing Campaigns subplaybook.
 
 ## Playbooks ##
 
@@ -93,7 +100,10 @@ The **Phishing Campaign Incident** layout contains the following additional tabs
   
   ![image](https://user-images.githubusercontent.com/53567272/128185701-12025b48-0a2b-4e38-b4eb-c7c96fe285f6.png)
 
-    
+The Campaign Overview tab consists of dynamic sections. These sections are based on the context inside the Phishing Campaign incident. It uses the context to dynamically fetch information from the related Phishing incidents and display aggregated data in the Phishing Campaign incident.
+
+The context is managed through the Detect & Manage Phishing Campaign playbook, and should not be modified manually.
+
   |Layout Section| Description |
   |--|--| 
   |Campaign Summary| Includes information about the phishing incidents that make up the campaign. Some fields display the number of phishing incidents (in parenthesis) in which every detail of the campaign was observed.|
@@ -112,16 +122,19 @@ Enables the analyst to take batch actions:
 |--|--|
 |Similar Incidents| Similar phishing incidents are displayed.  The columns are the same incident fields in the `fieldToDisplay` input in the [Detect & Manage Phishing Campaign](https://xsoar.pan.dev/docs/reference/playbooks/detect--manage-phishing-campaigns) playbook, so analysts can decide what to see about their related incidents.|
 |Notify Recipients| Analysts can select which incident, recipients, etc, to send an email.  The recipients from the incidents are auto-populated in the **Campaign Email To** field. Analysts can write an email and send it to the recipients directly from the layout.|
-|Incident Actions| The related incidents can be linked (occurs automatically by default in the playbook), unlinked, closed and reopened.|
+|Incident Actions| The related incidents can be linked (occurs automatically by default in the playbook), unlinked, closed and reopened. The user can also self-assign incidents in batch ("Take Ownership" action).|
 
 ## Before You Start ##
 ### Required Content Packs
+- Phishing Campaign (this pack)
+- Phishing
+- Cortex Lock
 - Base
 - Common Playbooks
 - Common Scripts
 - Common Types
-- Phishing
 
 ## Pack Configuration
 
 Customize the playbook by changing the inputs of the  [Detect & Manage Phishing Campaigns](https://xsoar.pan.dev/docs/reference/playbooks/detect--manage-phishing-campaigns) playbook. All of the playbook inputs customize the execution of the **FindEmailCampaign** automation.
+In addition, the Demisto Lock integration should be configured to ensure that duplicate Phishing Campaign incidents are not created for the same campaign.

--- a/content-repo/extra-docs/packs/Phishing-Campaign.md
+++ b/content-repo/extra-docs/packs/Phishing-Campaign.md
@@ -57,10 +57,11 @@ If incidents belonging to a campaign are detected, the playbook checks whether t
 
 In addition, as the **FindEmailCampaign** automation runs on the current phishing incident, the playbook takes the context and incident fields set by the automation, and updates the Phishing Campaign incident with that data, so that it contains the most up to date information about the phishing incidents.
 
-The playbook marks all the similar Phishing incidents as incidents belonging to the detected Phishing Campaign incident. It sets the **Part Of Campaign** incident field in the phishing incidents, with the ID of the phishing campaign incident:
+Updating the data in the Phishing Campaign incident is mostly done using the **SetPhishingCampaignDetails ** automation, which ensures that the context is updated correctly without incidents overwriting each other's context.
+
+The playbook also marks all the similar Phishing incidents as incidents belonging to the detected Phishing Campaign incident. It sets the **Part Of Campaign** incident field in the phishing incidents, with the ID of the phishing campaign incident:
 
 ![image](https://user-images.githubusercontent.com/43602124/127866753-93e7ce42-2c11-474e-b492-0fb07dc751db.png)
-
 
 
 ## Incident Types ##

--- a/content-repo/extra-docs/packs/Phishing-Campaign.md
+++ b/content-repo/extra-docs/packs/Phishing-Campaign.md
@@ -1,4 +1,3 @@
-
 ---
 id: phishing-campaign
 title: Phishing Campaign

--- a/content-repo/extra-docs/packs/Phishing-Campaign.md
+++ b/content-repo/extra-docs/packs/Phishing-Campaign.md
@@ -7,9 +7,9 @@ description: How to detect and manage phishing campaigns in Cortex XSOAR using t
 
 # Phishing Campaign #
 
-The Phishing Campaign pack enables you to find, create and manage phishing campaigns. A phishing campaign is a collection of phishing incidents that originate from the same attacker, or as part of the same organized attack launched against multiple users.
+The Phishing Campaign pack enables you to find, create, and manage phishing campaigns. A phishing campaign is a collection of phishing incidents that originate from the same attacker, or as part of the same organized attack launched against multiple users.
 
-As phishing campaigns are a number of phishing incidents that are similar to each other, it is important to detect and create the links between them, and look at them as a whole, rather than spend time investigating each incident separately. To see how to set up a phishing incident generally in Cortex XSOAR, go to the [Phishing Use Case Tutorial](https://docs.paloaltonetworks.com/cortex/cortex-xsoar/6-2/cortex-xsoar-tutorials/tutorials/phishing-use-case.html).
+As phishing campaigns are a number of phishing incidents that are similar to each other, it is important to detect and create the links between them, and look at them as a whole, rather than spend time investigating each incident separately. To see how to set up a phishing incident generally in Cortex XSOAR, go to the [Phishing Use Case Tutorial](https://docs-cortex.paloaltonetworks.com/r/Cortex-XSOAR/6.x/Cortex-XSOAR-6.x-Tutorials/Set-up-a-Phishing-Incident-in-Cortex-XSOAR).
 
 
 ### How It Works
@@ -39,13 +39,14 @@ The **Phishing Campaign** content pack contains several content items.
   The automation can also be customized to meet different criteria (if your email information is mapped into different fields, if your incident type has a different name, or if the similarity by which incidents are searched is too lenient or too strict). It can run to detect phishing campaigns, but to fully utilize it to detect and manage campaigns, use the [**Detect & Manage Phishing Campaigns**](https://xsoar.pan.dev/docs/reference/playbooks/detect--manage-phishing-campaigns) playbook. 
 - **IsIncidentPartOfCampaign Automation**
  
-  The **IsIncidentPartOfCampaign** automation takes the list of incidents detected as similar by the **FindEmailCampaign** automation, and checks whether one of them is already linked to a Phishing Campaign incident. If so, it outputs the ID of that incident so that all the similar phishing incidents can be linked to it. This automation finds whether there is an existing campaign incident or whether a new incident needs to be created.
+  The **IsIncidentPartOfCampaign** automation takes the list of incidents detected as similar by the **FindEmailCampaign** automation and checks whether one of them is already linked to a Phishing Campaign incident. If so, it outputs the ID of that incident so that all similar phishing incidents can be linked to it. This automation finds whether there is an existing campaign incident or whether a new incident needs to be created.
 
 - **SetPhishingCampaignDetails Automation**
-The **SetPhishingCampaignDetails** automation updates the Phishing Campaign incident that was found, or was just created by the playbook, with new information outputted from the **FindEmailCampaign** script.
+
+  The **SetPhishingCampaignDetails** automation updates the Phishing Campaign incident that was found or was just created by the playbook, with new information outputted from the **FindEmailCampaign** script.
 Specifically, if the current phishing incident is not already in the context of the Phishing Campaign incident, it will add that incident along with its data. It will also update the similarities of all the Phishing incidents that are part of that Phishing Campaign incident, relative to the incident that was *created* last.
 
-**Note:** The last created incident is not necessarily the last incident that updated the Phishing Campaign. This is due to the nature of phishing campaigns, where multiple phishing incidents are typically processed at the same time. This behavior in managed through a lock mechanism which ensures that the incidents are processed synchronously (one by one). However, it cannot be guaranteed that the first ingested incident will be the first to acquire the lock and the first to be processed, since different incidents may take different amount of time to reach the Detect & Manage Phishing Campaigns subplaybook.
+**Note:** The last created incident is not necessarily the last incident that updated the Phishing Campaign. This is due to the nature of phishing campaigns, where multiple phishing incidents are typically processed at the same time. This behavior is managed through a lock mechanism which ensures that the incidents are processed synchronously (one by one). However, it cannot be guaranteed that the first ingested incident will be the first to acquire the lock and the first to be processed, since different incidents may take different amounts of time to reach the Detect & Manage Phishing Campaigns subplaybook.
 
 ## Playbooks ##
 
@@ -55,11 +56,11 @@ The **Detect & Manage Phishing Campaigns** playbook uses the **FindEmailCampaign
 
 If incidents belonging to a campaign are detected, the playbook checks whether the incidents are already linked to a Phishing Campaign incident. If so, the currently investigated incident is also added to that campaign incident. If not, a new Phishing Campaign incident is created, and all similar incidents are linked to it.
 
-In addition, as the **FindEmailCampaign** automation runs on the current phishing incident, the playbook takes the context and incident fields set by the automation, and updates the Phishing Campaign incident with that data, so that it contains the most up to date information about the phishing incidents.
+In addition, as the **FindEmailCampaign** automation runs on the current phishing incident, the playbook takes the context and incident fields set by the automation, and updates the Phishing Campaign incident with that data, so that it contains the most up-to-date information about the phishing incidents.
 
 Updating the data in the Phishing Campaign incident is mostly done using the **SetPhishingCampaignDetails ** automation, which ensures that the context is updated correctly without incidents overwriting each other's context.
 
-The playbook also marks all the similar Phishing incidents as incidents belonging to the detected Phishing Campaign incident. It sets the **Part Of Campaign** incident field in the phishing incidents, with the ID of the phishing campaign incident:
+The playbook also marks all similar Phishing incidents as incidents belonging to the detected Phishing Campaign incident. It sets the **Part Of Campaign** incident field in the phishing incidents, with the ID of the phishing campaign incident:
 
 ![image](https://user-images.githubusercontent.com/43602124/127866753-93e7ce42-2c11-474e-b492-0fb07dc751db.png)
 


### PR DESCRIPTION
## Status
Ready

## Related Issues
fixes: https://jira-hq.paloaltonetworks.local/browse/CIAC-8096

## Description
Updated the phishing campaign article. Specifically:
- Added information about the **SetPhishingCampaignDetails** automation
- Added more information about the layout and how the dynamic sections work
- Added information to explain how similarity is updated
- Added a note explaining that the context in the Phishing Campaign incident should not be modified
- Added references and explanations about the Demisto Lock integration and how it's being used in the Detect & Manage Phishing Campaigns playbook
- Updated an old link to the phishing v2 playbook to point to the **Phishing - Generic v3** playbook
- Updated the available actions from the layout

