### PR TITLE
remove unnecessary calls

### DIFF
--- a/docs/integrations/mirroring.md
+++ b/docs/integrations/mirroring.md
@@ -174,7 +174,7 @@ def update_remote_system_command(client: Client, args: Dict[str, Any]) -> str:
     """
     parsed_args = UpdateRemoteSystemArgs(args)
     if parsed_args.delta:
-        demisto.debug(f'Got the following delta keys {str(list(parsed_args.delta.keys()))}')
+        demisto.debug(f'Got the following delta keys {list(parsed_args.delta)}')
         
     demisto.debug(f'Sending incident with remote ID [{parsed_args.remote_incident_id}] to remote system\n')
     new_incident_id: str = parsed_args.remote_incident_id


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Status
Ready

## Description
`str` is unnecessary in a formatted string, `.keys()` in unnecessary in a call to `list`
