### PR TITLE
Use the correct key for Contents

### DIFF
--- a/docs/integrations/code-conventions.md
+++ b/docs/integrations/code-conventions.md
@@ -1029,7 +1029,7 @@ demisto.results(
     {
         'Type': EntryType.NOTE,
         'ContentsFormat': EntryFormat.TEXT,
-        'Content': res,
+        'Contents': res,
         'HumanReadable': 'Submitted file is being analyzed.',
         'ReadableContentsFormat': EntryFormat.MARKDOWN,
         'EntryContext': entry_context,


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Status
Ready

## Description
Fixes the key for demisto.results from Content to Contents. The function will not work as intended if the key is incorrect. Correct usage can be seen in the content repo: https://github.com/search?q=repo%3Ademisto%2Fcontent+demisto.results+contents&type=code

