### PR TITLE
Deactivate smelly default previously set in Python integration code conventions

### DIFF
--- a/docs/integrations/code-conventions.md
+++ b/docs/integrations/code-conventions.md
@@ -28,8 +28,10 @@ from CommonServerUserPython import *
 import json
 import urllib3
 
-# Disable insecure warnings
-urllib3.disable_warnings()
+# Convert warnings to full-on errors for better/more cautious insights
+warnings.filterwarnings("error")
+# The line below can be used to disable insecure warnings
+# urllib3.disable_warnings()
 ```
 
 ## Constants 


### PR DESCRIPTION
I recently inherited a custom integration written by one of our engineers at the time.
He had (understandably) started off by pasting a bunch of code snippets from the code conventions and then built the functionality for our specific usecase on top of that.
One of the snippets that survived until now was the Imports section, which contains a call to `urllib3.disable_warnings()`.

After stumbling over that call, digging through the docs and confirming that it indeed was part of the official conventions, I was a bit concerned. Considering XSOAR is a Security platform, I'd say opting in to behavior like that in the code conventions is unbecoming to say the least ...

I do not think this is a sensible default. If people choose to fire off requests without certificate validation, that's their choice, but let's not encourage that behavior by including the associated setup in a doc that serves as a de facto template for lots of custom integrations.

The line in question is now commented out. Since warnings aren't visible when running an integration (at least not in the Frontend, when running the integration on the platform itself, idk about running locally) I also used `warnings.filterwarnings` to turn any warnings into errors by default.