### PR TITLE
[Content Packs Structure] Added Allowed Values For `certification`

### DIFF
--- a/docs/packs/packs-format.md
+++ b/docs/packs/packs-format.md
@@ -5,7 +5,7 @@ title: Content Packs Structure
 
 For better separation between Content artifacts from different use cases and Partners we use a directory structure called `Content Packs`. Each `Content Pack` behaves like a mini content repo. It contains all relevant content items within its directory.
 
-For instance a pack for CortexXDR will look as can be seen in the Content Repository 
+For instance a pack for CortexXDR will look as can be seen in the Content Repository
 [Packs/CortexXDR](https://github.com/demisto/content/tree/master/Packs/CortexXDR).
 
 To generate a new pack make sure to use: `demisto-sdk init --pack`. Detailed command instructions are available [here](https://github.com/demisto/demisto-sdk/blob/master/demisto_sdk/commands/init/README.md).
@@ -13,8 +13,10 @@ To generate a new pack make sure to use: `demisto-sdk init --pack`. Detailed com
 **Note**: The Content repo is going through a transition phase to move all content into packs. During this phase you will see some Content artifacts are still not maintained within Packs. All new Content should be maintained via Packs.
 
 ## Directories  
+
 All the directories within the pack are the representation of all the possible entities possible in Content. And the pack will be located in the Content repo under `Packs/<Pack Name>`
-```
+
+```text
 - Integrations        
 - Scripts
 - Playbooks
@@ -31,12 +33,14 @@ All the directories within the pack are the representation of all the possible e
 ```
 
 ## Pack files
-The pack directory contains numerous configuration files used for metadata and documentation. 
 
-Please note that all of the following files will be created using the `demisto-sdk init --pack`, and some of them 
+The pack directory contains numerous configuration files used for metadata and documentation.
+
+Please note that all of the following files will be created using the `demisto-sdk init --pack`, and some of them
 will have to be filled by you. An explanation for each of them will be provided below.
- 
+
 ### pack_metadata.json
+
 This file contains all the relevant metadata about the pack.
 
 The following fields are populated in the pack metadata:
@@ -62,9 +66,8 @@ The following fields are populated in the pack metadata:
 | displayedImages | List | (Optional) Images to be displayed in Cortex XSOAR marketplace. Should be kept empty on pack creation, as it is calculated by Cortex XSOAR content infrastructure. |
 | githubUser | List | (Optional) List of Github usernames to receive notification in the PR in case pack files were modified. |
 | devEmail | List | (Optional) List of emails to receive notification in case contributed pack files were modified. |
-| certification | String | (Optional) If the pack is certifed the value of this fields should be "certified" |
-| itemPrefix | String | (Optional) String to overwrite pack fields prefix. You can specify an alternative string instead of the default pack name enforced by the validation process.
-
+| certification | String | (Optional) If the pack is certified the value of this fields should be "certified". The allowed values are either "certified" or "verified". |
+| itemPrefix | String | (Optional) String to overwrite pack fields prefix. You can specify an alternative string instead of the default pack name enforced by the validation process. |
 
 Pack metadata contents for example:
 
@@ -110,6 +113,7 @@ Pack metadata contents for example:
 ```
 
 A supported partner pack metadata contents for example:
+
 ```json
 {
     "name": "Product name",
@@ -134,47 +138,53 @@ A supported partner pack metadata contents for example:
 }
 ```
 
-
 ### Content Packs Versioning
+
 Pack versions have the following format MAJOR.MINOR.REVISION:
+
    1. **Revision** when you make backwards compatible bug fixes.
    2. **Minor** when you add functionality in a backwards compatible manner.
    3. **Major** when you make incompatible API changes or revamping the pack by adding to it a lot of new backwards compatible functionality.
 
-
 ### README.md
+
 The file contains a general explanation for the pack and you are free to add any information relevant for the pack. For more details refer to the [Pack Documentation](../documentation/pack-docs) page.
 
 ### .secrets-ignore
+
 This file will be used while running the `demisto-sdk secrets`([explanation](https://github.com/demisto/demisto-sdk/blob/master/demisto_sdk/commands/secrets/README.md)), we will determine the file and will
  use it as an allow list of approved words for your PR.
 
 **Note**: We use `demisto-sdk secrets` as part of our pre-commit hook to check that possible secrets in the PR aren't exposed to a public repository.
 
 ### .pack-ignore
+
 1) This file allows ignoring linter errors while lint checking and ignoring tests in the test collection.
 
    To add ignored tests/linter errors in a file, first, add the file name to the **.pack-ignore** in this format
-```
-[file:integration-to-ignore.yml]
-```
 
-On the following line add `ignore=` flag, with one or more comma-separated values:
-* `auto-test` - ignore test file in the build test collection.
-* `linter code` e.g., IN126 - ignore linter error codes.
+    ```text
+    [file:integration-to-ignore.yml]
+    ```
+
+    On the following line add `ignore=` flag, with one or more comma-separated values:
+
+    * `auto-test` - ignore test file in the build test collection.
+    * `linter code` e.g., IN126 - ignore linter error codes.
 
 2) By default, unit-tests of scripts/integrations are running without a docker network.
 
    In case one of the integrations/scripts inside a pack needs a network during the unit-tests run, this can be done in this format
 
-```
-[tests_require_network]
-integration-id-1
-script-id-1
-```
+    ```text
+    [tests_require_network]
+    integration-id-1
+    script-id-1
+    ```
 
 #### Example .pack-ignore
-```
+
+```text
 [file:playbook-Special-Test-Not-To-Run-Directly.yml]
 ignore=auto-test
 
@@ -187,6 +197,7 @@ script-id-1
 ```
 
 ### Author_image.png
+
 It's possible to add an author image - a logo of the contributing company, which will be displayed on the marketplace page of the pack, under the "PUBLISHER" section.  
 The image should be saved in the root directory of the pack (e.g., `content/packs/MyPackName`), be named `Author_image.png`, and have a size of up to 4 KB, at a resolution of 120x50.
 
@@ -198,16 +209,19 @@ If the file is missing, the build will fail with the following validation error:
 - Issues with unique files in pack: $PACK_NAME
   Packs/$PACK_NAME/Author_image.png: [IM109] - Partners must provide a non-empty author image under the path Packs/$PACK_NAME/Author_image.png
 ```
+
 :::
- 
+
 :::note
 If the `Author_image.png` file does not exist, the name of the author will be displayed under the "PUBLISHER" section instead.
 :::
 
 ### CONTRIBUTORS.json
-If you are contributing to an existing pack, you can add a **CONTRIBUTORS.json** file to the root of the pack in the event that one does not already exist. The file should contain a list of strings including your name. 
 
-#### Example of a CONTRIBUTORS.json file:
+If you are contributing to an existing pack, you can add a **CONTRIBUTORS.json** file to the root of the pack in the event that one does not already exist. The file should contain a list of strings including your name.
+
+#### Example of a CONTRIBUTORS.json file
+
 ```json
 [
     "Jane Doe",
@@ -215,7 +229,6 @@ If you are contributing to an existing pack, you can add a **CONTRIBUTORS.json**
 ]
 ```
 
-#### Once your contribution is merged, pack details will show the following:
+#### Once your contribution is merged, pack details will show the following
 
 ![image](https://user-images.githubusercontent.com/44666568/176713193-8a0857bf-a5ed-45cd-98e4-3c575752c0ff.png)
-

--- a/docs/packs/packs-format.md
+++ b/docs/packs/packs-format.md
@@ -15,8 +15,7 @@ To generate a new pack make sure to use: `demisto-sdk init --pack`. Detailed com
 ## Directories  
 
 All the directories within the pack are the representation of all the possible entities possible in Content. And the pack will be located in the Content repo under `Packs/<Pack Name>`
-
-```text
+```
 - Integrations        
 - Scripts
 - Playbooks
@@ -66,7 +65,7 @@ The following fields are populated in the pack metadata:
 | displayedImages | List | (Optional) Images to be displayed in Cortex XSOAR marketplace. Should be kept empty on pack creation, as it is calculated by Cortex XSOAR content infrastructure. |
 | githubUser | List | (Optional) List of Github usernames to receive notification in the PR in case pack files were modified. |
 | devEmail | List | (Optional) List of emails to receive notification in case contributed pack files were modified. |
-| certification | String | (Optional) If the pack is certified the value of this fields should be "certified". The allowed values are either "certified" or "verified". |
+| certification | String | (Optional) If the pack is certified the value of this fields should be "certified". The allowed values are "certified" and "verified". |
 | itemPrefix | String | (Optional) String to overwrite pack fields prefix. You can specify an alternative string instead of the default pack name enforced by the validation process. |
 
 Pack metadata contents for example:
@@ -163,7 +162,7 @@ This file will be used while running the `demisto-sdk secrets`([explanation](htt
 
    To add ignored tests/linter errors in a file, first, add the file name to the **.pack-ignore** in this format
 
-    ```text
+    ```toml
     [file:integration-to-ignore.yml]
     ```
 
@@ -176,7 +175,7 @@ This file will be used while running the `demisto-sdk secrets`([explanation](htt
 
    In case one of the integrations/scripts inside a pack needs a network during the unit-tests run, this can be done in this format
 
-    ```text
+    ```toml
     [tests_require_network]
     integration-id-1
     script-id-1
@@ -184,7 +183,7 @@ This file will be used while running the `demisto-sdk secrets`([explanation](htt
 
 #### Example .pack-ignore
 
-```text
+```toml
 [file:playbook-Special-Test-Not-To-Run-Directly.yml]
 ignore=auto-test
 
@@ -229,6 +228,6 @@ If you are contributing to an existing pack, you can add a **CONTRIBUTORS.json**
 ]
 ```
 
-#### Once your contribution is merged, pack details will show the following
+#### Once your contribution is merged, pack details will show the following:
 
 ![image](https://user-images.githubusercontent.com/44666568/176713193-8a0857bf-a5ed-45cd-98e4-3c575752c0ff.png)

--- a/docs/packs/packs-format.md
+++ b/docs/packs/packs-format.md
@@ -161,29 +161,26 @@ This file will be used while running the `demisto-sdk secrets`([explanation](htt
 1) This file allows ignoring linter errors while lint checking and ignoring tests in the test collection.
 
    To add ignored tests/linter errors in a file, first, add the file name to the **.pack-ignore** in this format
+```
+[file:integration-to-ignore.yml]
+```
 
-    ```toml
-    [file:integration-to-ignore.yml]
-    ```
-
-    On the following line add `ignore=` flag, with one or more comma-separated values:
-
-    * `auto-test` - ignore test file in the build test collection.
-    * `linter code` e.g., IN126 - ignore linter error codes.
+On the following line add `ignore=` flag, with one or more comma-separated values:
+* `auto-test` - ignore test file in the build test collection.
+* `linter code` e.g., IN126 - ignore linter error codes.
 
 2) By default, unit-tests of scripts/integrations are running without a docker network.
 
    In case one of the integrations/scripts inside a pack needs a network during the unit-tests run, this can be done in this format
 
-    ```toml
-    [tests_require_network]
-    integration-id-1
-    script-id-1
-    ```
+```
+[tests_require_network]
+integration-id-1
+script-id-1
+```
 
 #### Example .pack-ignore
-
-```toml
+```
 [file:playbook-Special-Test-Not-To-Run-Directly.yml]
 ignore=auto-test
 
@@ -208,9 +205,8 @@ If the file is missing, the build will fail with the following validation error:
 - Issues with unique files in pack: $PACK_NAME
   Packs/$PACK_NAME/Author_image.png: [IM109] - Partners must provide a non-empty author image under the path Packs/$PACK_NAME/Author_image.png
 ```
-
 :::
-
+ 
 :::note
 If the `Author_image.png` file does not exist, the name of the author will be displayed under the "PUBLISHER" section instead.
 :::
@@ -219,8 +215,7 @@ If the `Author_image.png` file does not exist, the name of the author will be di
 
 If you are contributing to an existing pack, you can add a **CONTRIBUTORS.json** file to the root of the pack in the event that one does not already exist. The file should contain a list of strings including your name.
 
-#### Example of a CONTRIBUTORS.json file
-
+#### Example of a CONTRIBUTORS.json file:
 ```json
 [
     "Jane Doe",


### PR DESCRIPTION
## Description
Added allowed values for `certification` filed
The allowed values are either "certified" or "verified".
(Validate PA118)

## Screenshots
![image](https://github.com/demisto/content-docs/assets/69422117/d444e159-8413-4856-8f93-306b4e6394d9)

