### PR TITLE
Fix typo in code-conventions.md

### DIFF
--- a/docs/integrations/code-conventions.md
+++ b/docs/integrations/code-conventions.md
@@ -534,7 +534,7 @@ def get_ip(ip):
 ```
 **Note:** These logging methods replace the deprecated ```LOG()``` function.
 
-## Do No Print Sensitive Data to The Log
+## Do Not Print Sensitive Data to the Log
 This section is critical. When an integration is ready to be used as part of a public release (meaning you are done debugging it), we **ALWAYS** remove print statements that are not absolutely necessary.
 
 


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Status
Ready

## Related Issues
https://jira-dc.paloaltonetworks.com/browse/CRTXDOC-2754

## Description
The heading in https://xsoar.pan.dev/docs/integrations/code-conventions#do-no-print-sensitive-data-to-the-log
should be 
Do Not Print Sensitive Data to the Log

## Screenshots
Paste here any images that will help the reviewer
