### PR TITLE
Add note about printing debug logs

### DIFF
--- a/docs/tutorials/tut-integration-ui.md
+++ b/docs/tutorials/tut-integration-ui.md
@@ -366,6 +366,8 @@ except Exception as e:
 ```
 If any errors occur during the execution of our code, show those errors to the user and also return an error.
 
+**NOTE:** demisto.debug must be used to print debug logs. Using a print statement can cause unexpected exceptions and errors.
+
 ### Start at Main
 ```python
 if __name__ in ('__main__', '__builtin__', 'builtins'):


### PR DESCRIPTION
<!-- REMINDER: THIS IS A PUBLIC REPO DO NOT POST HERE SECRETS/SENSITIVE DATA -->

## Status
Ready/In Progress/In Hold (Reason for hold)

## Related Issues
fixes: link to the issue

## Description
@Bharathwaj-Murali wrote in Slack (https://panw-global.slack.com/archives/C01225PADU1/p1736790008630149):
Can this docs be updated in this section https://xsoar.pan.dev/docs/tutorials/tut-integration-ui#integration-code to indicate that demisto.debug must be used to print debug logs? Using print statement can cause unexpected exceptions and errors.
https://panw-global.slack.com/archives/C011E5T5K17/p1715157686327079
I just had a customer report issue and they used print in the integration code. Replacing that with demisto.debug fixed the issue. Can we update the docs to ensure we have it noted?

## Screenshots
Paste here any images that will help the reviewer
