### PR TITLE
Pin github actions

### DIFF
--- a/.github/workflows/auto-assign-issues.yml
+++ b/.github/workflows/auto-assign-issues.yml
@@ -11,6 +11,6 @@ jobs:
             issues: write
         steps:
             - name: 'Auto assign issue'
-              uses: pozil/auto-assign-issue@v1
+              uses: pozil/auto-assign-issue@d11e715efc663fe323c3d8d4d3cbbfdddd539baf # v1
               with:
                   assignees: ShirleyDenkberg,richardbluestone

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,32 +10,32 @@ jobs:
   build:
     runs-on: ubuntu-22.04
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       with:
         fetch-depth: 0
     - name: Read .nvmrc
       run: echo ::set-output name=NVMRC::$(cat .nvmrc)  # see: https://help.github.com/en/actions/automating-your-workflow-with-github-actions/development-tools-for-github-actions#set-an-output-parameter-set-output
       id: nvm
     - name: Set up node
-      uses: actions/setup-node@v1
+      uses: actions/setup-node@f1f314fca9dfce2769ece7d933488f076716723e # v1
       with:
         node-version: "${{ steps.nvm.outputs.NVMRC }}"
     - name: Cache npm
-      uses: actions/cache@v4
+      uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4
       with:
         path: ~/.npm
         key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
         restore-keys: |
           ${{ runner.os }}-node-
     - name: Cache pip
-      uses: actions/cache@v4
+      uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4
       with:
         path: ~/.cache/pip
         key: ${{ runner.os }}-pip-${{ hashFiles('**/Pipfile.lock') }}
         restore-keys: |
           ${{ runner.os }}-pip-
     - run: npm ci
-    - uses: actions/setup-python@v1
+    - uses: actions/setup-python@0f07f7f756721ebd886c2462646a35f78a8bc4de # v1
       with:
         python-version: '3.9'
     - name: Setup pipenv

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -24,19 +24,19 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4 # https://github.com/marketplace/actions/checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4 # https://github.com/marketplace/actions/checkout
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v2
+        uses: github/codeql-action/init@b8d3b6e8af63cde30bdc382c0bc28114f4346c88 # v2
         with:
           languages: ${{ matrix.language }}
           queries: +security-and-quality
 
       - name: Autobuild
-        uses: github/codeql-action/autobuild@v2
+        uses: github/codeql-action/autobuild@b8d3b6e8af63cde30bdc382c0bc28114f4346c88 # v2
         if: ${{ matrix.language == 'javascript' || matrix.language == 'python' }}
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v2
+        uses: github/codeql-action/analyze@b8d3b6e8af63cde30bdc382c0bc28114f4346c88 # v2
         with:
           category: "/language:${{ matrix.language }}"

--- a/.github/workflows/links-verify.yml
+++ b/.github/workflows/links-verify.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
     - name: content checkout
-      uses: actions/checkout@v4  # https://github.com/marketplace/actions/checkout
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4  # https://github.com/marketplace/actions/checkout
       with:
         repository: demisto/content
         path: content
@@ -18,7 +18,7 @@ jobs:
         fetch-depth: 0
         ref: 'master'
     - name: content-docs checkout
-      uses: actions/checkout@v4  # https://github.com/marketplace/actions/checkout
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4  # https://github.com/marketplace/actions/checkout
       with:
         repository: demisto/content-docs
         path: content-docs
@@ -35,7 +35,7 @@ jobs:
         cat content-docs/urls_ignore.txt >> all_urls_ignore.txt
         cat all_urls_ignore.txt
     - name: Set up Go 1.13
-      uses: actions/setup-go@v2
+      uses: actions/setup-go@bfdd3570ce990073878bf10f6b2d79082de49492 # v2
       with:
         go-version: 1.13.11
       id: go
@@ -56,7 +56,7 @@ jobs:
         echo "All good! muffet passed!!!"
     - name: Save artifcats
       if: ${{ always() }}
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@82c141cc518b40d92cc801eee768e7aafc9c2fa2 # v2
       with:
         name: log-artifacts
         path: muffet.txt


### PR DESCRIPTION
GitHub recommends pinning actions to a full length commit SHA, as this is currently the only method of using an action as an immutable release.

For more information refer to: https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions