### PR TITLE
feat: add Unit42 Feed (deprecated) to ignored integrations list

### DIFF
--- a/content-repo/ignored_entities.json
+++ b/content-repo/ignored_entities.json
@@ -7,7 +7,8 @@
   "integrations": [
     "PICUS",
     "KnowBe4KMSAT",
-    "Netskope (API v2)"
+    "Netskope (API v2)",
+    "Unit42 Feed"
   ],
   "scripts": [
 


### PR DESCRIPTION
## Status
Ready

## Related Issues
fixes: https://panw-global.slack.com/archives/C091N069V70/p1760601444943199

## Description
Ignore the deprecated Unit 42 Feed integration since it will be collapsed with the new Unit 42 Feed
The problem is that we have two similar integrations

1. Unit42 Feed
2. Unit 42 Feed

But after [normalizing](https://github.com/demisto/content-docs/blob/master/content-repo/gendocs.py#L831), both of them are the same.
So we have a workaround (for other integrations as well) to ignore the old feed integration.

## Screenshots
Paste here any images that will help the reviewer
