### PR TITLE
Update signature_with_def option in pydocs generator

### DIFF
--- a/content-repo/gen_pydocs.py
+++ b/content-repo/gen_pydocs.py
@@ -218,6 +218,7 @@ def generate_pydoc(
         classdef_code_block=False,
         descriptive_class_title=False,
         signature_with_decorators=False,
+        signature_with_def=False,
         signature_class_prefix=True,
         render_module_header=False,
         format_code=False,

--- a/content-repo/gen_pydocs_test.py
+++ b/content-repo/gen_pydocs_test.py
@@ -63,7 +63,9 @@ def test_generate_pydoc_demisto_class(tmp_path):
             assert f.readline().startswith('## ')
             f.readline()
             assert f.readline().startswith('```python')
-            assert f.readline().startswith(func_prefix)
+            sig_line = f.readline()
+            assert sig_line.startswith(func_prefix), f"Signature should start with '{func_prefix}', got: {sig_line}"
+            assert not sig_line.startswith(f"{func_prefix}def "), f"Signature should not contain 'def' after prefix, got: {sig_line}"
 
 
 def test_generate_pydoc_common_server_python(tmp_path):


### PR DESCRIPTION
## Status
Ready

## Related Issues
fixes: [CRTX-238825](https://jira-dc.paloaltonetworks.com/browse/CRTX-238825)

## Description
The bug was introduced by commit [fef4c9a](https://github.com/demisto/content-docs/commit/fef4c9a) ("migrate pydoc markdown to v4 #1853") on March 23, 2026.

In pydoc-markdown v3 (3.10.0), `MarkdownRenderer.signature_with_def` defaulted to `False`.
In pydoc-markdown v4 (>=4.8.2), `MarkdownRenderer.signature_with_def` defaults to `True`.

The migration did NOT add `signature_with_def=False` to the `DemistoMarkdownRenderer` instantiation in `generate_pydoc()`, causing `def ` to be prepended to all function signatures in code blocks.

